### PR TITLE
Added Option to Request Each Smirks is Exercised More than Once.

### DIFF
--- a/nistdataselection/curatedataset.py
+++ b/nistdataselection/curatedataset.py
@@ -5,150 +5,18 @@ import functools
 import logging
 import math
 import os
-import re
 import sys
 from collections import defaultdict
-from enum import Enum
 
 import numpy
-from openforcefield.topology import Molecule, Topology
-from openforcefield.typing.engines import smirnoff
-from openforcefield.utils import UndefinedStereochemistryError
-from propertyestimator.client import PropertyEstimatorOptions
+from openforcefield.topology import Molecule
+from propertyestimator import unit
 from propertyestimator.datasets import PhysicalPropertyDataSet
-from propertyestimator.layers import SimulationLayer
 from propertyestimator.properties import Density, DielectricConstant, EnthalpyOfVaporization
-from propertyestimator.protocols.groups import ConditionalGroup
 from propertyestimator.utils import setup_timestamp_logging
-from propertyestimator.workflow import WorkflowOptions
-from simtk import unit
-from tabulate import tabulate
 
 from nistdataselection.utils import PandasDataSet
-from nistdataselection.utils.utils import smiles_to_png
-
-
-class ReportType(Enum):
-    """An enum which records how information about the
-    chosen set (e.g. which properties do we have which
-    data for) should be presented.
-    """
-    LateX = 'LateX'
-    PlainText = 'PlainText'
-
-
-class SubstanceType(Enum):
-    """An enum which encodes the names used for substances
-    with different numbers of components.
-    """
-    Pure = 'pure'
-    Binary = 'binary'
-    Ternary = 'ternary'
-
-
-_cached_smirks_parameters = {}
-
-
-def _find_smirks_parameters(parameter_tag='vdW', *smiles_patterns):
-    """Finds those force field parameters with a given tag which
-    would be assigned to a specified set of molecules defined by
-    the their smiles patterns.
-
-    Parameters
-    ----------
-    parameter_tag: str
-        The tag of the force field parameters to find.
-    smiles_patterns: str
-        The smiles patterns to assign the force field parameters
-        to.
-
-    Returns
-    -------
-    dict of str and list of str
-        A dictionary with keys of parameter smirks patterns, and
-        values of lists of smiles patterns which would utilize
-        those parameters.
-    """
-
-    force_field = smirnoff.ForceField('smirnoff99Frosst-1.0.9.offxml')
-    parameter_handler = force_field.get_parameter_handler(parameter_tag)
-
-    smiles_by_parameter_smirks = {}
-
-    # Initialize the array with all possible smirks pattern
-    # to make it easier to identify which are missing.
-    for parameter in parameter_handler.parameters:
-
-        if parameter.smirks in smiles_by_parameter_smirks:
-            continue
-
-        smiles_by_parameter_smirks[parameter.smirks] = set()
-
-    # Populate the dictionary using the open force field toolkit.
-    for smiles in smiles_patterns:
-
-        if smiles not in _cached_smirks_parameters or parameter_tag not in _cached_smirks_parameters[smiles]:
-
-            try:
-                molecule = Molecule.from_smiles(smiles)
-            except UndefinedStereochemistryError:
-                # Skip molecules with undefined stereochemistry.
-                continue
-
-            topology = Topology.from_molecules([molecule])
-
-            if smiles not in _cached_smirks_parameters:
-                _cached_smirks_parameters[smiles] = {}
-
-            if parameter_tag not in _cached_smirks_parameters[smiles]:
-                _cached_smirks_parameters[smiles][parameter_tag] = []
-
-            _cached_smirks_parameters[smiles][parameter_tag] = [
-                parameter.smirks for parameter in force_field.label_molecules(topology)[0][parameter_tag].values()
-            ]
-
-        parameters_with_tag = _cached_smirks_parameters[smiles][parameter_tag]
-
-        for smirks in parameters_with_tag:
-            smiles_by_parameter_smirks[smirks].add(smiles)
-
-    return smiles_by_parameter_smirks
-
-
-def _count_parameters_per_molecule(parameter_tag='vdW', *smiles_patterns):
-    """Returns the frequency that a certain number of parameters with a given
-     tag (e.g. 'vdW') get assigned to a list of molecules defined by their
-     smiles patterns.
-
-    Parameters
-    ----------
-    parameter_tag: str
-        The parameter tag.
-    smiles_patterns: str
-        The smiles patterns which define the list of molecules.
-
-    Returns
-    -------
-    dict of int and int
-        The counted frequencies.
-    """
-
-    smiles_by_parameter_smirks = _find_smirks_parameters(parameter_tag, *smiles_patterns)
-
-    parameter_smirks_by_smiles = defaultdict(list)
-
-    for smirks_pattern in smiles_by_parameter_smirks:
-        for smiles_pattern in smiles_by_parameter_smirks[smirks_pattern]:
-            parameter_smirks_by_smiles[smiles_pattern].append(smirks_pattern)
-
-    counts = defaultdict(int)
-
-    for smiles_pattern in parameter_smirks_by_smiles:
-
-        number_of_parameters = len(parameter_smirks_by_smiles[smiles_pattern])
-        counts[number_of_parameters] += 1
-
-    return counts
+from nistdataselection.utils.utils import SubstanceType, find_smirks_parameters, cached_smirks_parameters
 
 
 def _find_common_smiles_patterns(*data_sets):
@@ -280,7 +148,7 @@ def _remove_duplicates(data_set):
                 properties_by_substance[substance_id][property_type] = {}
 
             # Partition the properties by state.
-            temperature = physical_property.thermodynamic_state.temperature.value_in_unit(unit.kelvin)
+            temperature = physical_property.thermodynamic_state.temperature.to(unit.kelvin).magnitude
 
             if physical_property.thermodynamic_state.pressure is None:
 
@@ -288,7 +156,7 @@ def _remove_duplicates(data_set):
 
             else:
 
-                pressure = physical_property.thermodynamic_state.pressure.value_in_unit(unit.kilopascal)
+                pressure = physical_property.thermodynamic_state.pressure.to(unit.kilopascal).magnitude
                 state_tuple = (f'{temperature:.2f}', f'{pressure:.3f}')
 
             if state_tuple not in properties_by_substance[substance_id][property_type]:
@@ -309,16 +177,16 @@ def _remove_duplicates(data_set):
             base_unit = None
 
             if isinstance(existing_uncertainty, unit.Quantity):
-                base_unit = existing_uncertainty.unit
+                base_unit = existing_uncertainty.units
 
             elif isinstance(current_uncertainty, unit.Quantity):
-                base_unit = current_uncertainty.unit
+                base_unit = current_uncertainty.units
 
             if base_unit is not None and isinstance(existing_uncertainty, unit.Quantity):
-                existing_uncertainty = existing_uncertainty.value_in_unit(base_unit)
+                existing_uncertainty = existing_uncertainty.to(base_unit).magnitude
 
             if base_unit is not None and isinstance(current_uncertainty, unit.Quantity):
-                current_uncertainty = current_uncertainty.value_in_unit(base_unit)
+                current_uncertainty = current_uncertainty.to(base_unit).magnitude
 
             if (math.isinf(existing_uncertainty) and math.isinf(current_uncertainty) or
                 existing_uncertainty < current_uncertainty):
@@ -459,7 +327,7 @@ def _extract_min_max_median_temperature_set(data_set):
         temperatures = []
 
         for physical_property in data_set.properties[substance_id]:
-            temperatures.append(physical_property.thermodynamic_state.temperature.value_in_unit(unit.kelvin))
+            temperatures.append(physical_property.thermodynamic_state.temperature.to(unit.kelvin).magnitude)
 
         if len(temperatures) <= 0:
             continue
@@ -484,7 +352,7 @@ def _extract_min_max_median_temperature_set(data_set):
     return filtered_set
 
 
-def _choose_molecule_set(data_sets, properties_of_interest):
+def _choose_molecule_set(data_sets, properties_of_interest, desired_properties_per_smirks=2):
     """Selects the minimum set of molecules which (if possible) simultaneously have
     data for all three properties, and exercise the largest number of vdW
     parameters.
@@ -506,6 +374,10 @@ def _choose_molecule_set(data_sets, properties_of_interest):
     properties_of_interest: list of tuple of type and SubstanceType
         A list of the properties which are of interest to optimise against.
 
+    desired_properties_per_smirks: int
+        The number of each type of property which should
+        ideally exercise each smirks pattern.
+
     Returns
     -------
     dict of str and set of str
@@ -517,7 +389,7 @@ def _choose_molecule_set(data_sets, properties_of_interest):
     smirks_exercised_per_property = {}
 
     for property_type, _ in properties_of_interest:
-        smirks_exercised_per_property[property_type] = set()
+        smirks_exercised_per_property[property_type] = defaultdict(int)
 
     # Define the order of preference for which data molecules should have,
     # as explained above.
@@ -535,21 +407,21 @@ def _choose_molecule_set(data_sets, properties_of_interest):
             (Density, SubstanceType.Pure),
             (EnthalpyOfVaporization, SubstanceType.Pure)
         ],
-        [
-            # and molecules for which we have at least densities and
-            # dielectric constant
-            (Density, SubstanceType.Pure),
-            (DielectricConstant, SubstanceType.Pure),
-        ],
+        # [
+        #     # and molecules for which we have at least densities and
+        #     # dielectric constant
+        #     (Density, SubstanceType.Pure),
+        #     (DielectricConstant, SubstanceType.Pure),
+        # ],
         [
             # Finally, fall back to molecules for which the is only
             # data for the enthalpy of vaporisation...
             (EnthalpyOfVaporization, SubstanceType.Pure)
         ],
-        [
-            # or the density.
-            (Density, SubstanceType.Pure),
-        ]
+        # [
+        #     # or the density.
+        #     (Density, SubstanceType.Pure),
+        # ]
     ]
 
     for property_list in property_order:
@@ -560,7 +432,7 @@ def _choose_molecule_set(data_sets, properties_of_interest):
             *[data_sets[property_tuple] for property_tuple in property_list]
         )
 
-        smiles_per_vdw_smirks = _find_smirks_parameters('vdW', *common_smiles)
+        smiles_per_vdw_smirks = find_smirks_parameters('vdW', *common_smiles)
 
         unexercised_smirks_per_smiles = defaultdict(set)
 
@@ -580,7 +452,7 @@ def _choose_molecule_set(data_sets, properties_of_interest):
 
             for property_type, _ in property_list:
 
-                if smirks in smirks_exercised_per_property[property_type]:
+                if smirks_exercised_per_property[property_type][smirks] >= desired_properties_per_smirks:
                     continue
 
                 all_properties_exercised = False
@@ -637,17 +509,35 @@ def _choose_molecule_set(data_sets, properties_of_interest):
             exercised_smirks = unexercised_smirks_per_smiles.pop(smiles)
 
             chosen_smiles[smiles] = set([smirks for smirks, values in
-                                         _find_smirks_parameters('vdW', smiles).items() if len(values) > 0])
+                                         find_smirks_parameters('vdW', smiles).items() if len(values) > 0])
 
             for exercised_smirks_pattern in exercised_smirks:
                 for property_type, _ in property_list:
-                    smirks_exercised_per_property[property_type].add(exercised_smirks_pattern)
+                    smirks_exercised_per_property[property_type][exercised_smirks_pattern] += 1
 
             # Update the dictionary to reflect that a number of
             # smirks patterns have now been exercised.
             for remaining_smiles in unexercised_smirks_per_smiles:
-                unexercised_smirks_per_smiles[remaining_smiles] = unexercised_smirks_per_smiles[
-                    remaining_smiles].difference(exercised_smirks)
+
+                for smirks in exercised_smirks:
+
+                    if smirks not in unexercised_smirks_per_smiles[remaining_smiles]:
+                        continue
+
+                    smirks_fully_exercised = True
+
+                    for property_type, _ in property_list:
+
+                        if smirks_exercised_per_property[property_type][smirks] >= desired_properties_per_smirks:
+                            continue
+
+                        smirks_fully_exercised = False
+                        break
+
+                    if not smirks_fully_exercised:
+                        continue
+
+                    unexercised_smirks_per_smiles[remaining_smiles].remove(smirks)
 
             # Remove empty dictionary entries
             unexercised_smirks_per_smiles = {smiles: smirks_set for smiles, smirks_set in
@@ -660,45 +550,6 @@ def _choose_molecule_set(data_sets, properties_of_interest):
                 resorted_smiles.append(key)
 
             sorted_smiles = resorted_smiles
-
-    # Construct a dictionary which expresses which data we have
-    # for each smirks pattern.
-    properties_exercised_by_smirks = defaultdict(set)
-
-    for property_type, smirks_list in smirks_exercised_per_property.items():
-        for smirks_pattern in smirks_list:
-            properties_exercised_by_smirks[smirks_pattern].add(property_type)
-
-    # Print information about those vdw parameters for which
-    # no matched smiles patterns were found.
-    all_vdw_smirks = set(_find_smirks_parameters('vdW').keys())
-
-    for smirks in all_vdw_smirks:
-
-        if smirks not in properties_exercised_by_smirks:
-            continue
-
-        property_string = ', '.join([property_type.__name__ for property_type in
-                                     properties_exercised_by_smirks[smirks]])
-
-        exercising_molecules = set()
-
-        for smiles in chosen_smiles:
-
-            if smirks not in chosen_smiles[smiles]:
-                continue
-
-            exercising_molecules.add(smiles)
-
-        logging.info(f'{smirks} was exercised by the {property_string} property types '
-                     f'and {", ".join(exercising_molecules)} molecules.')
-
-    for smirks in all_vdw_smirks:
-
-        if smirks in properties_exercised_by_smirks:
-            continue
-
-        logging.info(f'{smirks} was not exercised.')
 
     return chosen_smiles
 
@@ -761,8 +612,8 @@ def _choose_data_points(data_set, properties_of_interest, target_state_points):
 
         pressure, temperature = state_tuple
 
-        distance_tuple = ((target_state_point[1].value_in_unit(unit.kilopascal) - pressure) ** 2,
-                          (target_state_point[0].value_in_unit(unit.kelvin) - temperature) ** 2)
+        distance_tuple = ((target_state_point[1].to(unit.kilopascal).magnitude - pressure) ** 2,
+                          (target_state_point[0].to(unit.kelvin).magnitude - temperature) ** 2)
 
         return distance_tuple
 
@@ -779,8 +630,8 @@ def _choose_data_points(data_set, properties_of_interest, target_state_points):
         # according to the `state_distance` metric.
         for physical_property in data_set.properties[substance_id]:
 
-            temperature = physical_property.thermodynamic_state.temperature.value_in_unit(unit.kelvin)
-            pressure = physical_property.thermodynamic_state.pressure.value_in_unit(unit.kilopascal)
+            temperature = physical_property.thermodynamic_state.temperature.to(unit.kelvin).magnitude
+            pressure = physical_property.thermodynamic_state.pressure.to(unit.kilopascal).magnitude
 
             state_tuple = (round(pressure, 3), round(temperature, 2))
 
@@ -789,8 +640,8 @@ def _choose_data_points(data_set, properties_of_interest, target_state_points):
 
             for cluster_index, target_state_point in enumerate(target_state_points):
 
-                distance = math.sqrt((target_state_point[0].value_in_unit(unit.kelvin) - temperature) ** 2 +
-                                     (target_state_point[1].value_in_unit(unit.kilopascal) - pressure) ** 2)
+                distance = math.sqrt((target_state_point[0].to(unit.kelvin).magnitude - temperature) ** 2 +
+                                     (target_state_point[1].to(unit.kilopascal).magnitude - pressure) ** 2)
 
                 if distance >= shortest_cluster_distance:
                     continue
@@ -849,296 +700,7 @@ def _choose_data_points(data_set, properties_of_interest, target_state_points):
     return return_data_set
 
 
-def _estimate_required_simulations(properties_of_interest, data_set):
-    """Estimate how many simulations the property estimator
-    will try and run to estimate the given data set of properties.
-
-    Parameters
-    ----------
-    properties_of_interest: list of tuple of type and SubstanceType
-        A list of the property types which are of interest to optimise against.
-    data_set: PhysicalPropertyDataSet
-        The data set containing the data set of properties of interest.
-
-    Returns
-    -------
-    int
-        The estimated number of simulations required.
-    """
-
-    data_set = PhysicalPropertyDataSet.parse_json(data_set.json())
-
-    options = PropertyEstimatorOptions()
-    calculation_layer = 'SimulationLayer'
-
-    for property_type, _ in properties_of_interest:
-
-        options.workflow_options[property_type.__name__] = {calculation_layer: WorkflowOptions()}
-
-        default_schema = property_type.get_default_workflow_schema(calculation_layer, WorkflowOptions())
-        options.workflow_schemas[property_type.__name__] = {calculation_layer: default_schema}
-
-    properties = []
-
-    for substance_id in data_set.properties:
-        properties.extend(data_set.properties[substance_id])
-
-    workflow_graph = SimulationLayer._build_workflow_graph('', properties, '', [], options)
-
-    number_of_simulations = 0
-
-    for protocol_id in workflow_graph._protocols_by_id:
-
-        protocol = workflow_graph._protocols_by_id[protocol_id]
-
-        if not isinstance(protocol, ConditionalGroup):
-            continue
-
-        number_of_simulations += 1
-
-    return number_of_simulations
-
-
-def _create_report(report_type, file_path, chosen_smiles, properties_of_interest,
-                   final_data_set):
-    """Create a formated report about the chosen data, and optionally
-    save it to file.
-
-    Parameters
-    ----------
-    report_type: ReportType
-        The format in which to print the report.
-    file_path: str
-        The location to save the report to.
-    chosen_smiles: dict of str and set of str
-        The smile patterns of the chosen molecules, and the
-        vdW smirks patterns they exercise.
-    properties_of_interest: list of tuple of type and SubstanceType
-        The properties of interest.
-    final_data_set: PhysicalPropertyDataSet
-        The complete, curated data set.
-    """
-    if report_type == ReportType.PlainText:
-        _create_report_plain_text(file_path, chosen_smiles, properties_of_interest, final_data_set)
-    elif report_type == ReportType.LateX:
-        _create_report_latex(file_path, chosen_smiles, properties_of_interest, final_data_set)
-    else:
-        raise NotImplementedError()
-
-
-def _create_report_plain_text(file_path, chosen_smiles, properties_of_interest, final_data_set):
-    """Create a plain text report about the chosen data.
-
-    Parameters
-    ----------
-    file_path: str
-        The location to save the report to.
-    chosen_smiles: dict of str and set of str
-        The smile patterns of the chosen molecules, and the
-        vdW smirks patterns they exercise.
-    properties_of_interest: list of tuple of type and SubstanceType
-        The properties of interest.
-    final_data_set: PhysicalPropertyDataSet
-        The complete, curated data set.
-
-    Returns
-    -------
-    str
-        The create report.
-    """
-
-    with open(file_path, 'w') as file:
-
-        file.write('\n')
-        file.write(f'A total of {final_data_set.number_of_properties} data points are to '
-                   f'be optimized against.\n')
-
-        # Print information about the chosen set
-        for smiles_pattern in chosen_smiles:
-
-            file.write(''.join(['-'] * 120))
-            file.write(f'\nSMILES: {smiles_pattern}\n')
-            file.write(f'VDW SMIRKS EXERCISED: {" ".join(chosen_smiles[smiles_pattern])}')
-
-            for property_type, substance_type in properties_of_interest:
-
-                def filter_by_substance_type(physical_property):
-
-                    substance_type_to_int = {
-                        SubstanceType.Pure: 1,
-                        SubstanceType.Binary: 2,
-                        SubstanceType.Ternary: 3,
-                    }
-
-                    return substance_type_to_int[substance_type] == len(physical_property.substance.components)
-
-                copied_data_set = PhysicalPropertyDataSet.parse_json(final_data_set.json())
-                copied_data_set.filter_by_property_types(property_type)
-                copied_data_set.filter_by_function(filter_by_substance_type)
-
-                property_name = ' '.join(re.sub('([A-Z][a-z]+)', r' \1',
-                                                re.sub('([A-Z]+)', r' \1', property_type.__name__)).split())
-
-                file.write(f'\n{str(substance_type.value).upper()} {property_name.upper()} Data\n')
-
-                pandas_data_frame = PandasDataSet.to_pandas_data_frame(copied_data_set)
-                pandas_data_frame = pandas_data_frame.loc[pandas_data_frame['Component 1'] == smiles_pattern]
-
-                pandas_data_frame = pandas_data_frame[['Temperature (K)', 'Pressure (kPa)', 'Source']]
-
-                pandas_data_frame.sort_values('Temperature (K)')
-                pandas_data_frame.sort_values('Pressure (kPa)')
-
-                file.write(tabulate(pandas_data_frame, headers='keys', tablefmt='psql', showindex=False))
-
-        file.write(''.join(['-'] * 120))
-        file.write('\n')
-
-
-def _create_report_latex(file_path, chosen_smiles, properties_of_interest, final_data_set):
-    """Create a LaTeX formated report about the chosen data.
-
-    Parameters
-    ----------
-    file_path: str
-        The location to save the report to.
-    chosen_smiles: dict of str and set of str
-        The smile patterns of the chosen molecules, and the
-        vdW smirks patterns they exercise.
-    properties_of_interest: list of tuple of type and SubstanceType
-        The properties of interest.
-    """
-
-    # Save images of the chosen molecules
-    os.makedirs('images', exist_ok=True)
-    _create_molecule_images(list(chosen_smiles.keys()), 'images')
-
-    required_simulations = _estimate_required_simulations(properties_of_interest, final_data_set)
-
-    header_template = [
-        '\\documentclass{article}',
-        '\\usepackage[margin=3cm]{geometry}',
-        '',
-        '\\usepackage[utf8]{inputenc}',
-        '\\usepackage{graphicx}',
-        '\\usepackage{array}',
-        '\\usepackage[export]{adjustbox}',
-        '\\usepackage{parskip}',
-        '',
-        '\\usepackage{url}',
-        '\\urlstyle{same}',
-        '',
-        '\\begin{document}',
-        '',
-        '\\begin{center}',
-        '    \\LARGE{Chosen Data Set} \\\\ \\vspace{.2cm}',
-        '    \\large{\\url{https://github.com/openforcefield/nistdataselection}}',
-        '\\end{center}',
-        '',
-        f'A total of {final_data_set.number_of_properties} data points covering '
-        f'{len(final_data_set.properties)} unique molecules are to be optimized against. '
-        f'This will require approximately {required_simulations} unique simulation to be '
-        f'performed.',
-        ''
-    ]
-
-    row_templates = []
-
-    # Print information about the chosen set
-    for smiles_pattern in chosen_smiles:
-
-        exercised_smirks = []
-
-        for smirks in chosen_smiles[smiles_pattern]:
-            exercised_smirks.append(f'\\item {{{smirks}}}'.replace('#', '\\#'))
-
-        safe_smiles_pattern = smiles_pattern.replace("#", "\\#")
-
-        row_template = [
-            '\\hrulefill',
-            '',
-            '\\vspace{.3cm}',
-            '\\begin{center}',
-            f'    \\large{{\\textbf{{{safe_smiles_pattern}}}}}',
-            '\\end{center}'
-            '\\vspace{.3cm}',
-            '',
-            '\\begin{tabular}{ m{5cm} m{9cm} }',
-            '    {Structure} & {SMIRKS Exercised} \\\\',
-            f'    {{\\catcode`\\#=12 \\includegraphics{{{"./images/" + smiles_pattern + ".png"}}}}} & '
-            f'\\begin{{itemize}} {" ".join(exercised_smirks)} \\end{{itemize}} \\\\',
-            '\\end{tabular}'
-        ]
-
-        for property_type, substance_type in properties_of_interest:
-
-            def filter_by_substance_type(physical_property):
-
-                substance_type_to_int = {
-                    SubstanceType.Pure: 1,
-                    SubstanceType.Binary: 2,
-                    SubstanceType.Ternary: 3,
-                }
-
-                return substance_type_to_int[substance_type] == len(physical_property.substance.components)
-
-            data_set = PhysicalPropertyDataSet.parse_json(final_data_set.json())
-            data_set.filter_by_property_types(property_type)
-            data_set.filter_by_function(filter_by_substance_type)
-
-            pandas_data_frame = PandasDataSet.to_pandas_data_frame(data_set)
-            pandas_data_frame = pandas_data_frame.loc[pandas_data_frame['Component 1'] == smiles_pattern]
-
-            if pandas_data_frame.shape[0] == 0:
-                continue
-
-            pandas_data_frame = pandas_data_frame[['Temperature (K)', 'Pressure (kPa)', 'Source']]
-            pandas_data_frame = pandas_data_frame.sort_values(['Pressure (kPa)', 'Temperature (K)'])
-
-            property_name = ' '.join(re.sub('([A-Z][a-z]+)', r' \1',
-                                            re.sub('([A-Z]+)', r' \1', property_type.__name__)).split())
-
-            row_template.append(f'\n{str(substance_type.value).title()} {property_name.title()} Data\n')
-            row_template.append('\\vspace{.3cm}\n')
-            row_template.append(tabulate(pandas_data_frame, headers='keys', tablefmt='latex', showindex=False))
-            row_template.append('\\vspace{.3cm}\n')
-
-        row_templates.append('\n'.join(row_template))
-
-    end_template = '\\end{document}\n'
-
-    with open(file_path, 'w') as file:
-
-        file.write('\n'.join(header_template))
-        file.write('\n')
-        file.write('\n'.join(row_templates))
-        file.write('\n')
-        file.write(end_template)
-
-
-def _create_molecule_images(chosen_smiles, directory):
-    """Creates a PNG image of the 2D representation of each
-    molecule represented in a list of smiles patterns.
-
-    Parameters
-    ----------
-    chosen_smiles: list of str
-        The list of molecule smiles representations.
-    directory: str
-        The directory to save the created images in.
-    """
-    os.makedirs(directory, exist_ok=True)
-
-    for smiles in chosen_smiles:
-
-        file_name = smiles.replace('/', '').replace('\\', '')
-        file_path = os.path.join(directory, f'{file_name}.png')
-
-        smiles_to_png(smiles, file_path)
-
-
-def curate_data_set(property_data_directory, output_data_set_path='curated_data_set.json',
-                    report_type=ReportType.LateX, report_path='report.tex'):
+def curate_data_set(property_data_directory, output_data_set_path='curated_data_set.json'):
     """The main function which will perform the
     data curation.
 
@@ -1269,10 +831,6 @@ def curate_data_set(property_data_directory, output_data_set_path='curated_data_
     with open(output_data_set_path, 'w') as file:
         file.write(final_data_set.json())
 
-    # Print the chosen molecule set and the corresponding data to the terminal.
-    _create_report(report_type, report_path, chosen_smiles,
-                   properties_of_interest, final_data_set)
-
 
 def _main():
     """A utility function for calling this script directly, which
@@ -1293,7 +851,7 @@ def _main():
     try:
 
         with open(cached_smirks_file_name) as file:
-            _cached_smirks_parameters.update(json.load(file))
+            cached_smirks_parameters.update(json.load(file))
 
     except (json.JSONDecodeError, FileNotFoundError):
         pass
@@ -1305,7 +863,7 @@ def _main():
     # Cache the smirks which will be assigned to the different molecules
     # to speed up future runs.
     with open(cached_smirks_file_name, 'w') as file:
-        json.dump(_cached_smirks_parameters, file)
+        json.dump(cached_smirks_parameters, file)
 
 
 if __name__ == '__main__':

--- a/nistdataselection/generatereport.py
+++ b/nistdataselection/generatereport.py
@@ -1,0 +1,383 @@
+"""
+Records the tools and decisions used to select NIST data for curation.
+"""
+import os
+import re
+from collections import defaultdict
+
+import pandas
+from propertyestimator.client import PropertyEstimatorOptions
+from propertyestimator.datasets import PhysicalPropertyDataSet
+from propertyestimator.layers import SimulationLayer
+from propertyestimator.properties import Density, DielectricConstant, EnthalpyOfVaporization, MeasurementSource
+from propertyestimator.protocols.groups import ConditionalGroup
+from propertyestimator.utils import setup_timestamp_logging
+from propertyestimator.workflow import WorkflowOptions
+from tabulate import tabulate
+
+from nistdataselection.utils import PandasDataSet
+from nistdataselection.utils.utils import smiles_to_png, cached_smirks_parameters, find_smirks_parameters, \
+    int_to_substance_type, substance_type_to_int
+
+
+def _estimate_required_simulations(properties_of_interest, data_set):
+    """Estimate how many simulations the property estimator
+    will try and run to estimate the given data set of properties.
+
+    Parameters
+    ----------
+    properties_of_interest: list of tuple of type and SubstanceType
+        A list of the property types which are of interest to optimise against.
+    data_set: PhysicalPropertyDataSet
+        The data set containing the data set of properties of interest.
+
+    Returns
+    -------
+    int
+        The estimated number of simulations required.
+    """
+
+    data_set = PhysicalPropertyDataSet.parse_json(data_set.json())
+
+    options = PropertyEstimatorOptions()
+    calculation_layer = 'SimulationLayer'
+
+    for property_type, _ in properties_of_interest:
+
+        options.workflow_options[property_type.__name__] = {calculation_layer: WorkflowOptions()}
+
+        default_schema = property_type.get_default_workflow_schema(calculation_layer, WorkflowOptions())
+        options.workflow_schemas[property_type.__name__] = {calculation_layer: default_schema}
+
+    properties = []
+
+    for substance_id in data_set.properties:
+        properties.extend(data_set.properties[substance_id])
+
+    workflow_graph = SimulationLayer._build_workflow_graph('', properties, '', [], options)
+
+    number_of_simulations = 0
+
+    for protocol_id in workflow_graph._protocols_by_id:
+
+        protocol = workflow_graph._protocols_by_id[protocol_id]
+
+        if not isinstance(protocol, ConditionalGroup):
+            continue
+
+        number_of_simulations += 1
+
+    return number_of_simulations
+
+
+def _sanitize_identifier(identifier_pattern):
+
+    identifier_pattern = identifier_pattern.replace('\\', '\\\\')
+    identifier_pattern = identifier_pattern.replace('#', '\\#')
+
+    escaped_string = f'\\seqsplit{{{identifier_pattern}}}'
+    escaped_string.replace('~', r'\textasciitilde')
+
+    return escaped_string
+
+
+def _property_tuple_to_string(property_type, substance_type):
+
+    property_name = ' '.join(re.sub('([A-Z][a-z]+)', r' \1',
+                                    re.sub('([A-Z]+)', r' \1', property_type.__name__)).split())
+
+    return f'{str(substance_type.value).title()} {property_name.title()}'
+
+
+def _property_tuple_to_latex_symbol(property_type, substance_type):
+
+    property_type_to_symbol = {
+        Density: r'$\rho$',
+        DielectricConstant: r'$\epsilon_0$',
+        EnthalpyOfVaporization: r'$\Delta H_{vap}$',
+    }
+
+    return f'{str(substance_type.value).title()} {property_type_to_symbol[property_type]}'
+
+
+def _write_header(margin_size_cm=3):
+
+    return '\n'.join([
+        r'\documentclass{article}',
+        f'\\usepackage[margin={margin_size_cm}cm]{{geometry}}',
+        '',
+        r'\usepackage[utf8]{inputenc}',
+        r'\usepackage{graphicx}',
+        r'\usepackage{array}',
+        r'\usepackage[export]{adjustbox}',
+        r'\usepackage{parskip}',
+        '',
+        r'\usepackage{amssymb}',
+        r'\usepackage{seqsplit}',
+        '',
+        r'\usepackage{url}',
+        r'\urlstyle{same}',
+        '',
+        r'\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}'
+        '',
+        r'\begin{document}',
+    ])
+
+
+def _write_title(number_of_substances, number_of_properties, number_of_simulations):
+
+    return '\n'.join([
+        r'\begin{center}',
+        r'    \LARGE{Chosen Data Set}',
+        r'    \vspace{.2cm}',
+        r'    \large{\\url{https://github.com/openforcefield/nistdataselection}}',
+        r'\end{center}',
+        '',
+        f'A total of {number_of_properties} data points covering '
+        f'{number_of_substances} unique molecules are to be optimized against. '
+        f'This will require approximately {number_of_simulations} unique simulation to be '
+        f'performed.',
+    ])
+
+
+def _write_data_points_table(property_tuples, all_vdw_smirks, data_points_per_vdw_smirks):
+
+    columns = ['SMIRKS']
+    columns.extend([_property_tuple_to_latex_symbol(*property_tuple) for property_tuple in property_tuples])
+
+    rows = []
+
+    for smirks in all_vdw_smirks:
+
+        safe_smirks = _sanitize_identifier(smirks)
+        row = {'SMIRKS': f"'{safe_smirks}'"}
+
+        for property_tuple in property_tuples:
+
+            property_string = _property_tuple_to_latex_symbol(*property_tuple)
+            row[property_string] = data_points_per_vdw_smirks[smirks][property_tuple]
+
+        rows.append(row)
+
+    data_frame = pandas.DataFrame(data=rows, columns=columns)
+    data_frame.sort_values(columns[1:], ascending=False, inplace=True)
+
+    table_string_split = tabulate(data_frame, headers='keys', tablefmt='latex_raw', showindex=False).split('\n')
+    table_string_split = table_string_split[1:]
+
+    smirks_width = 13.5 - 1.0 * (len(columns) - 1)
+    header_string = f'{{m{{{smirks_width}cm}} ' + ' '.join(['C{1.0cm}' for _ in range(len(columns) - 1)]) + '}'
+
+    table_string = '\n'.join([
+        f'\\begin{{tabular}}{header_string}',
+        *table_string_split
+    ])
+
+    table_string = '\n'.join([
+        r'\vspace{.3cm}',
+        table_string,
+        r'\vspace{.3cm}'])
+
+    table_string = table_string.replace('\'\\', '\\')
+    table_string = table_string.replace('}\'', '}')
+
+    return table_string
+
+
+def _write_smiles_section(smiles_pattern, exercised_vdw_smirks_patterns, full_data_set, property_tuples):
+
+    exercised_smirks = [smirks for smirks in exercised_vdw_smirks_patterns if
+                        smiles_pattern in exercised_vdw_smirks_patterns[smirks]]
+
+    exercised_smirks_strings = [f'\\item {{{_sanitize_identifier(smirks)}}}' for smirks in exercised_smirks]
+
+    image_file_name = smiles_pattern.replace('/', '').replace('\\', '')
+
+    row_template = [
+        r'\hrulefill',
+        '',
+        r'\vspace{.3cm}',
+        r'\begin{center}',
+        f'    \\large{{\\textbf{{{_sanitize_identifier(smiles_pattern)}}}}}',
+        r'\end{center}'
+        r'\vspace{.3cm}',
+        '',
+        r'\begin{tabular}{ m{5cm} m{9cm} }',
+        '    {Structure} & {SMIRKS Exercised} \\\\',
+        f'    {{\\catcode`\\#=12 \\includegraphics{{{"./images/" + image_file_name + ".png"}}}}} & '
+        f'\\begin{{itemize}} {" ".join(exercised_smirks_strings)} \\end{{itemize}} \\\\',
+        r'\end{tabular}'
+    ]
+
+    for property_type, substance_type in property_tuples:
+
+        def filter_by_substance_type(physical_property):
+            return substance_type_to_int[substance_type] == len(physical_property.substance.components)
+
+        data_set = PhysicalPropertyDataSet.parse_json(full_data_set.json())
+        data_set.filter_by_property_types(property_type)
+        data_set.filter_by_function(filter_by_substance_type)
+
+        for substance_id in data_set.properties:
+
+            for physical_property in data_set.properties[substance_id]:
+
+                if len(physical_property.source.doi) > 0:
+                    continue
+
+                physical_property.source = MeasurementSource(
+                    reference=os.path.basename(physical_property.source.reference))
+
+        pandas_data_frame = PandasDataSet.to_pandas_data_frame(data_set)
+        pandas_data_frame = pandas_data_frame.loc[pandas_data_frame['Component 1'] == smiles_pattern]
+
+        if pandas_data_frame.shape[0] == 0:
+            continue
+
+        pandas_data_frame = pandas_data_frame[['Temperature (K)', 'Pressure (kPa)', 'Source']]
+        pandas_data_frame = pandas_data_frame.sort_values(['Pressure (kPa)', 'Temperature (K)'])
+
+        property_name = ' '.join(re.sub('([A-Z][a-z]+)', r' \1',
+                                        re.sub('([A-Z]+)', r' \1', property_type.__name__)).split())
+
+        row_template.append(f'\n{str(substance_type.value).title()} {property_name.title()} Data\n')
+        row_template.append('\\vspace{.3cm}\n')
+        row_template.append(tabulate(pandas_data_frame, headers='keys', tablefmt='latex', showindex=False))
+        row_template.append('\\vspace{.3cm}\n')
+
+    return '\n\n'.join(row_template)
+
+
+def _create_molecule_images(chosen_smiles, directory):
+    """Creates a PNG image of the 2D representation of each
+    molecule represented in a list of smiles patterns.
+
+    Parameters
+    ----------
+    chosen_smiles: list of str
+        The list of molecule smiles representations.
+    directory: str
+        The directory to save the created images in.
+    """
+    os.makedirs(directory, exist_ok=True)
+
+    for smiles in chosen_smiles:
+
+        file_name = smiles.replace('/', '').replace('\\', '')
+        file_path = os.path.join(directory, f'{file_name}.png')
+
+        smiles_to_png(smiles, file_path)
+
+
+def generate_report(data_set_path='curated_data_set.json', report_path='tmp.tex'):
+    """A helper utility which will take as input a PhysicalPropertyDataSet
+    and generate a report of its contents and coverage.
+
+    Parameters
+    ----------
+    data_set_path: str
+        The path to the data set.
+    report_type: ReportType
+        The type of report to create.
+    report_path: str
+        The path pointing to where to store the report.
+    """
+
+    setup_timestamp_logging()
+
+    with open(data_set_path) as file:
+        data_set = PhysicalPropertyDataSet.parse_json(file.read())
+
+    all_smiles = set()
+    all_property_types = set()
+
+    data_count_per_smiles = defaultdict(lambda: defaultdict(int))
+    data_per_smiles = defaultdict(lambda: defaultdict(list))
+
+    number_of_substances = len(data_set.properties)
+
+    for substance_id in data_set.properties:
+
+        if len(data_set.properties[substance_id]) == 0:
+            continue
+
+        for physical_property in data_set.properties[substance_id]:
+
+            substance_type = int_to_substance_type[physical_property.substance.number_of_components]
+            property_type_tuple = (type(physical_property), substance_type)
+
+            all_property_types.add(property_type_tuple)
+
+            for component in physical_property.substance.components:
+
+                all_smiles.add(component.smiles)
+                data_count_per_smiles[component.smiles][property_type_tuple] += 1
+
+                data_per_smiles[component.smiles][property_type_tuple].append(physical_property)
+
+    all_vdw_smirks_patterns = [smirks for smirks in find_smirks_parameters().keys()]
+    exercised_vdw_smirks_patterns = find_smirks_parameters('vdW', *all_smiles)
+
+    data_points_per_vdw_smirks = defaultdict(lambda: defaultdict(int))
+
+    for smirks in all_vdw_smirks_patterns:
+        for smiles in exercised_vdw_smirks_patterns[smirks]:
+            for data_tuple in data_count_per_smiles[smiles]:
+                data_points_per_vdw_smirks[smirks][data_tuple] += 1
+
+    number_of_simulations = _estimate_required_simulations(all_property_types, data_set)
+
+    _create_molecule_images(all_smiles, 'images')
+
+    smiles_sections = '\n'.join([_write_smiles_section(smiles, exercised_vdw_smirks_patterns,
+                                                       data_set, all_property_types) for smiles in all_smiles])
+
+    latex_document = '\n\n'.join([
+        _write_header(),
+        _write_title(number_of_substances, data_set.number_of_properties, number_of_simulations),
+        _write_data_points_table(all_property_types, all_vdw_smirks_patterns, data_points_per_vdw_smirks),
+        r'\pagebreak',
+        smiles_sections,
+        r'\end{document}'
+    ])
+
+    with open(report_path, 'w') as file:
+        file.write(latex_document)
+
+
+def _main():
+    """A utility function for calling this script directly, which
+    expects that the data files generated by the `parserawdata`
+    script are located in the '~/property_data' directory.
+    """
+
+    # home_directory = os.path.expanduser("~")
+    # data_directory = os.path.join(home_directory, 'property_data')
+
+    import json
+
+    # Check to see if we have already cached which vdW smirks will be
+    # assigned to which molecules. This can significantly speed up this
+    # script on multiple runs.
+    cached_smirks_file_name = 'cached_smirks_parameters.json'
+
+    try:
+
+        with open(cached_smirks_file_name) as file:
+            cached_smirks_parameters.update(json.load(file))
+
+    except (json.JSONDecodeError, FileNotFoundError):
+        pass
+
+    data_set_path = 'curated_data_set.json'
+
+    generate_report(data_set_path)
+
+    # Cache the smirks which will be assigned to the different molecules
+    # to speed up future runs.
+    with open(cached_smirks_file_name, 'w') as file:
+        json.dump(cached_smirks_parameters, file)
+
+
+if __name__ == '__main__':
+    _main()

--- a/nistdataselection/utils/pandasdataset.py
+++ b/nistdataselection/utils/pandasdataset.py
@@ -5,12 +5,11 @@ objects and `pandas.DataFrame` objects.
 import math
 
 import pandas
-from openforcefield.utils import quantity_to_string, string_to_quantity
+from propertyestimator import unit
 from propertyestimator.datasets import PhysicalPropertyDataSet
 from propertyestimator.properties import PropertyPhase, PhysicalProperty, MeasurementSource
 from propertyestimator.substances import Substance
 from propertyestimator.thermodynamics import ThermodynamicState
-from simtk import unit
 
 
 class PandasDataSet(PhysicalPropertyDataSet):
@@ -98,11 +97,11 @@ class PandasDataSet(PhysicalPropertyDataSet):
 
             if 'Value' in row:
                 value_string = row['Value'].replace('None', 'dimensionless')
-                value = string_to_quantity(value_string)
+                value = unit(value_string)
 
             if 'Uncertainty' in row:
                 uncertainty_string = row['Uncertainty'].replace('None', 'dimensionless')
-                uncertainty = string_to_quantity(uncertainty_string)
+                uncertainty = unit(uncertainty_string)
 
             source = MeasurementSource(reference=row['Source'])
             sources.add(source)
@@ -203,11 +202,11 @@ class PandasDataSet(PhysicalPropertyDataSet):
                                      'object')
 
                 # Extract the measured state.
-                temperature = physical_property.thermodynamic_state.temperature.value_in_unit(unit.kelvin)
+                temperature = physical_property.thermodynamic_state.temperature.to(unit.kelvin).magnitude
                 pressure = None
 
                 if physical_property.thermodynamic_state.pressure is not None:
-                    pressure = physical_property.thermodynamic_state.pressure.value_in_unit(unit.kilopascal)
+                    pressure = physical_property.thermodynamic_state.pressure.to(unit.kilopascal).magnitude
 
                 phase = physical_property.phase
 
@@ -226,11 +225,11 @@ class PandasDataSet(PhysicalPropertyDataSet):
                 # Extract the value data as a string.
                 # noinspection PyTypeChecker
                 value = (None if physical_property.value is None else
-                         quantity_to_string(physical_property.value))
+                         str(physical_property.value))
 
                 # noinspection PyTypeChecker
                 uncertainty = (None if physical_property.uncertainty is None else
-                               quantity_to_string(physical_property.uncertainty))
+                               str(physical_property.uncertainty))
 
                 # Extract the data source.
                 source = physical_property.source.reference


### PR DESCRIPTION
## Description

This PR makes the following changes to the data set selection algorithm:
  - An option has been added to allowing choosing the desired number of each type of property which should exercise each vdW smirks. The default for this option has been set to 2 - i.e. we would ideally have at least two data points per type of property per smirks pattern to be exercised.

  - Dielectric data is no longer included. It is unclear how much dielectric constants will improve the optimised parameters relative to the increased simulation cost. Further, it appears that the gradient of the dielectric constant with respect to the parameters being optimised is significantly more noisy than both densities and enthalpies of mixing, which could be detrimental to the optimisation procedure.

  - The allowed elements has been reduced to just those for which there is a reasonable amount of data, namely `'H', 'N', 'C', 'O', 'S', 'F', 'Cl', 'Br', 'I'`. In particular, `'P'` was removed for the reason of lack of data.

  - Molecules with a net charge are now properly filtered out.

Additionally, this PR:

  - Refactors the reporting methods into a separate utility, and now includes a table which indicates how many data points exercise each smirks pattern.
  - Swaps the repo to use pint.
  - Prints out which smirks are 'sufficiently exercised' to be optimised against.

## Status
- [x] Ready to go