### PR TITLE
Add Utility for Rendering Lists of SMILES

### DIFF
--- a/nistdataselection/utils/__init__.py
+++ b/nistdataselection/utils/__init__.py
@@ -10,6 +10,7 @@ from .utils import (
     invert_dict_of_list,
     log_filter,
     property_to_type_tuple,
+    smiles_to_pdf,
     standardize_smiles,
     substance_type_to_int,
 )
@@ -26,6 +27,7 @@ __all__ = [
     invert_dict_of_list,
     log_filter,
     property_to_type_tuple,
+    smiles_to_pdf,
     standardize_smiles,
     substance_type_to_int,
 ]


### PR DESCRIPTION
## Description
This PR adds a new `smiles_to_pdf` utility function which renders a set of molecules described by their SMILES patterns as a PDF file.

## Status
- [X] Ready to go