### PR TITLE
Fix Remove Duplicates with Missing Columns

### DIFF
--- a/nistdataselection/curation/filtering.py
+++ b/nistdataselection/curation/filtering.py
@@ -79,11 +79,9 @@ def filter_duplicates(data_set):
         uncertainty_header = header
 
     if uncertainty_header in data_set:
-        data_set.sort_values(uncertainty_header)
+        data_set = data_set.sort_values(uncertainty_header)
 
-    return data_set.drop_duplicates(
-        subset=subset_columns, keep="last"
-    )
+    return data_set.drop_duplicates(subset=subset_columns, keep="last")
 
 
 def filter_by_temperature(data_set, min_temperature, max_temperature):

--- a/nistdataselection/curation/filtering.py
+++ b/nistdataselection/curation/filtering.py
@@ -66,6 +66,8 @@ def filter_duplicates(data_set):
             ]
         )
 
+    subset_columns = [x for x in subset_columns if x in data_set]
+
     uncertainty_header = None
 
     for header in data_set:
@@ -76,7 +78,10 @@ def filter_duplicates(data_set):
         assert uncertainty_header is None
         uncertainty_header = header
 
-    return data_set.sort_values(uncertainty_header).drop_duplicates(
+    if uncertainty_header in data_set:
+        data_set.sort_values(uncertainty_header)
+
+    return data_set.drop_duplicates(
         subset=subset_columns, keep="last"
     )
 


### PR DESCRIPTION
## Description
This PR fixes an exception raised by the `filter_duplicates` function when the data set to filter did not have all of the expected (but optional) columns.

## Status
- [X] Ready to go