### PR TITLE
[Mixture] Filter Common Data Before State Selection

### DIFF
--- a/studies/mixture_feasibility/mixture_optimisation/data_set_generation/build_training_set.py
+++ b/studies/mixture_feasibility/mixture_optimisation/data_set_generation/build_training_set.py
@@ -4,11 +4,67 @@ import os
 from evaluator import unit
 from evaluator.properties import Density, EnthalpyOfMixing, ExcessMolarVolume
 
+from nistdataselection.curation.filtering import filter_by_temperature
 from nistdataselection.curation.selection import StatePoint, select_data_points
+from nistdataselection.processing import (
+    load_processed_data_set,
+    save_processed_data_set,
+)
 from nistdataselection.utils import SubstanceType
 from nistdataselection.utils.utils import data_frame_to_pdf
 
 logger = logging.getLogger(__name__)
+
+
+def filter_common_data(output_directory):
+    """Filter the common data to a smaller temperature range - this
+    seems to help the state selection method get closer to the target
+    states.
+    """
+    os.makedirs(os.path.join(output_directory, "h_mix_and_v_excess"), exist_ok=True)
+    os.makedirs(
+        os.path.join(output_directory, "h_mix_and_binary_density"), exist_ok=True
+    )
+
+    for property_type, substance_type in [
+        (EnthalpyOfMixing, SubstanceType.Binary),
+        (ExcessMolarVolume, SubstanceType.Binary),
+    ]:
+
+        data_frame = load_processed_data_set(
+            os.path.join("common_data", "h_mix_and_v_excess"),
+            property_type,
+            substance_type,
+        )
+        data_frame = filter_by_temperature(
+            data_frame, 290.0 * unit.kelvin, 305 * unit.kelvin
+        )
+        save_processed_data_set(
+            os.path.join(output_directory, "h_mix_and_v_excess"),
+            data_frame,
+            property_type,
+            substance_type,
+        )
+
+    for property_type, substance_type in [
+        (EnthalpyOfMixing, SubstanceType.Binary),
+        (Density, SubstanceType.Binary),
+    ]:
+
+        data_frame = load_processed_data_set(
+            os.path.join("common_data", "h_mix_and_binary_density"),
+            property_type,
+            substance_type,
+        )
+        data_frame = filter_by_temperature(
+            data_frame, 290.0 * unit.kelvin, 305 * unit.kelvin
+        )
+        save_processed_data_set(
+            os.path.join(output_directory, "h_mix_and_binary_density"),
+            data_frame,
+            property_type,
+            substance_type,
+        )
 
 
 def main():
@@ -43,8 +99,16 @@ def main():
         StatePoint(298.15 * unit.kelvin, 1.0 * unit.atmosphere, (0.75, 0.25)),
     ]
 
+    filtered_directory = "filtered_common_data"
+    os.makedirs(filtered_directory, exist_ok=True)
+
+    filter_common_data(filtered_directory)
+
+    output_directory = "training_sets"
+    os.makedirs(output_directory, exist_ok=True)
+
     h_mix_v_excess = select_data_points(
-        data_directory=os.path.join("common_data", "h_mix_and_v_excess"),
+        data_directory=os.path.join(filtered_directory, "h_mix_and_v_excess"),
         chosen_substances=substances,
         target_state_points={
             (EnthalpyOfMixing, SubstanceType.Binary): target_states,
@@ -52,14 +116,21 @@ def main():
         },
     )
 
-    h_mix_v_excess.json("h_mix_v_excess_training_set.json")
+    h_mix_v_excess.json(
+        os.path.join(output_directory, "h_mix_v_excess_training_set.json")
+    )
     h_mix_v_excess = h_mix_v_excess.to_pandas()
 
-    h_mix_v_excess.to_csv("h_mix_v_excess_training_set.csv", index=False)
-    data_frame_to_pdf(h_mix_v_excess, "h_mix_v_excess_training_set.pdf")
+    h_mix_v_excess.to_csv(
+        os.path.join(output_directory, "h_mix_v_excess_training_set.csv"), index=False
+    )
+    data_frame_to_pdf(
+        h_mix_v_excess,
+        os.path.join(output_directory, "h_mix_v_excess_training_set.pdf"),
+    )
 
     h_mix_density = select_data_points(
-        data_directory=os.path.join("common_data", "h_mix_and_binary_density"),
+        data_directory=os.path.join(filtered_directory, "h_mix_and_binary_density"),
         chosen_substances=substances,
         target_state_points={
             (EnthalpyOfMixing, SubstanceType.Binary): target_states,
@@ -67,11 +138,17 @@ def main():
         },
     )
 
-    h_mix_density.json("h_mix_density_training_set.json")
+    h_mix_density.json(
+        os.path.join(output_directory, "h_mix_density_training_set.json")
+    )
     h_mix_density = h_mix_density.to_pandas()
 
-    h_mix_density.to_csv("h_mix_density_training_set.csv", index=False)
-    data_frame_to_pdf(h_mix_density, "h_mix_density_training_set.pdf")
+    h_mix_density.to_csv(
+        os.path.join(output_directory, "h_mix_density_training_set.csv"), index=False
+    )
+    data_frame_to_pdf(
+        h_mix_density, os.path.join(output_directory, "h_mix_density_training_set.pdf")
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This PR adds an extra step to the mixture data training set construction - the common mixture data is now filtered to a more limited range before selecting the state and compositions of the data to include.

This was found to improve the selection algorithms ability to select data closer to the states / compositions of interest.

## Status
- [X] Ready to go