### PR TITLE
[Mixture] Set Stricter Convergence Critera

### DIFF
--- a/studies/mixture_feasibility/mixture_optimisation/force_balance/h_mix_binary_density/optimize.in
+++ b/studies/mixture_feasibility/mixture_optimisation/force_balance/h_mix_binary_density/optimize.in
@@ -18,16 +18,19 @@ jobtype optimize
 forcefield openff-1.0.0.offxml
 
 # (int) Maximum number of steps in an optimization
-maxstep 100
+maxstep 12
 
 # (float) Convergence criterion of step size (just needs to fall below this threshold)
 convergence_step 0.1
 
 # (float) Convergence criterion of objective function (in MainOptimizer this is the stdev of x2 over 10 steps)
-convergence_objective 0.1
+convergence_objective 0.0001
 
 # (float) Convergence criterion of gradient norm
-convergence_gradient 0.1
+convergence_gradient 0.001
+
+# The number of convergence criteria that must be met for main optimizer to converge
+criteria 3
 
 # (float) Minimum eigenvalue for applying steepest descent correction in the MainOptimizer
 eig_lowerbound 0.01

--- a/studies/mixture_feasibility/mixture_optimisation/force_balance/h_mix_v_excess/optimize.in
+++ b/studies/mixture_feasibility/mixture_optimisation/force_balance/h_mix_v_excess/optimize.in
@@ -18,16 +18,19 @@ jobtype optimize
 forcefield openff-1.0.0.offxml
 
 # (int) Maximum number of steps in an optimization
-maxstep 100
+maxstep 12
 
 # (float) Convergence criterion of step size (just needs to fall below this threshold)
 convergence_step 0.1
 
 # (float) Convergence criterion of objective function (in MainOptimizer this is the stdev of x2 over 10 steps)
-convergence_objective 0.1
+convergence_objective 0.0001
 
 # (float) Convergence criterion of gradient norm
-convergence_gradient 0.1
+convergence_gradient 0.001
+
+# The number of convergence criteria that must be met for main optimizer to converge
+criteria 3
 
 # (float) Minimum eigenvalue for applying steepest descent correction in the MainOptimizer
 eig_lowerbound 0.01

--- a/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_rho_x_rho_pure/optimize.in
+++ b/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_rho_x_rho_pure/optimize.in
@@ -18,16 +18,19 @@ jobtype optimize
 forcefield openff-1.0.0.offxml
 
 # (int) Maximum number of steps in an optimization
-maxstep 100
+maxstep 12
 
 # (float) Convergence criterion of step size (just needs to fall below this threshold)
 convergence_step 0.1
 
 # (float) Convergence criterion of objective function (in MainOptimizer this is the stdev of x2 over 10 steps)
-convergence_objective 0.1
+convergence_objective 0.0001
 
 # (float) Convergence criterion of gradient norm
-convergence_gradient 0.1
+convergence_gradient 0.001
+
+# The number of convergence criteria that must be met for main optimizer to converge
+criteria 3
 
 # (float) Minimum eigenvalue for applying steepest descent correction in the MainOptimizer
 eig_lowerbound 0.01

--- a/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_rho_x_rho_pure_h_vap/optimize.in
+++ b/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_rho_x_rho_pure_h_vap/optimize.in
@@ -18,16 +18,19 @@ jobtype optimize
 forcefield openff-1.0.0.offxml
 
 # (int) Maximum number of steps in an optimization
-maxstep 100
+maxstep 12
 
 # (float) Convergence criterion of step size (just needs to fall below this threshold)
 convergence_step 0.1
 
 # (float) Convergence criterion of objective function (in MainOptimizer this is the stdev of x2 over 10 steps)
-convergence_objective 0.1
+convergence_objective 0.0001
 
 # (float) Convergence criterion of gradient norm
-convergence_gradient 0.1
+convergence_gradient 0.001
+
+# The number of convergence criteria that must be met for main optimizer to converge
+criteria 3
 
 # (float) Minimum eigenvalue for applying steepest descent correction in the MainOptimizer
 eig_lowerbound 0.01

--- a/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_v_excess_rho_pure_h_vap/optimize.in
+++ b/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_v_excess_rho_pure_h_vap/optimize.in
@@ -18,16 +18,19 @@ jobtype optimize
 forcefield openff-1.0.0.offxml
 
 # (int) Maximum number of steps in an optimization
-maxstep 100
+maxstep 12
 
 # (float) Convergence criterion of step size (just needs to fall below this threshold)
 convergence_step 0.1
 
 # (float) Convergence criterion of objective function (in MainOptimizer this is the stdev of x2 over 10 steps)
-convergence_objective 0.1
+convergence_objective 0.0001
 
 # (float) Convergence criterion of gradient norm
-convergence_gradient 0.1
+convergence_gradient 0.001
+
+# The number of convergence criteria that must be met for main optimizer to converge
+criteria 3
 
 # (float) Minimum eigenvalue for applying steepest descent correction in the MainOptimizer
 eig_lowerbound 0.01

--- a/studies/mixture_feasibility/pure_optimisation/force_balance/optimize.in
+++ b/studies/mixture_feasibility/pure_optimisation/force_balance/optimize.in
@@ -18,16 +18,19 @@ jobtype optimize
 forcefield openff-1.0.0.offxml
 
 # (int) Maximum number of steps in an optimization
-maxstep 100
+maxstep 12
 
 # (float) Convergence criterion of step size (just needs to fall below this threshold)
 convergence_step 0.1
 
 # (float) Convergence criterion of objective function (in MainOptimizer this is the stdev of x2 over 10 steps)
-convergence_objective 0.1
+convergence_objective 0.0001
 
 # (float) Convergence criterion of gradient norm
-convergence_gradient 0.1
+convergence_gradient 0.001
+
+# The number of convergence criteria that must be met for main optimizer to converge
+criteria 3
 
 # (float) Minimum eigenvalue for applying steepest descent correction in the MainOptimizer
 eig_lowerbound 0.01
@@ -57,7 +60,7 @@ priors
 $end
 
 $target
-name pure_data
+name mixture_data
 type Evaluator_SMIRNOFF
 weight 1.0
 evaluator_input options.json


### PR DESCRIPTION
## Description
This PR addresses an issue where ForceBalance detects convergence of the optimization after a single iteration due to too lax convergence criteria.

Here the criteria has been tightened, with the intention that ForceBalance will instead run for 12 steps before exiting. This should be sufficient time to reach convergence - in most previous optimisations of the FF non-bonded terms the objective function has reached a minimum by the 4th step, after which it fluctuates around an average value.

## Status
- [x] Ready to go