### PR TITLE
[Mixture] Use Corrected Acid Hvap Measurements

### DIFF
--- a/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_rho_x_rho_pure_h_vap/targets/mixture_data/options.json
+++ b/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_rho_x_rho_pure_h_vap/targets/mixture_data/options.json
@@ -18,7 +18,7 @@
         "EnthalpyOfVaporization": {
             "@type": "evaluator.unit.Quantity",
             "unit": "kJ / mol",
-            "value": 6.191930232165088
+            "value": 5.742931305317869
         }
     },
     "estimation_options": {

--- a/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_rho_x_rho_pure_h_vap/targets/mixture_data/training_set.json
+++ b/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_rho_x_rho_pure_h_vap/targets/mixture_data/training_set.json
@@ -4,502 +4,7 @@
     {
       "@type": "evaluator.properties.density.Density",
       "gradients": [],
-      "id": "ff32f758b8c54a36ba12a585ae000671",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/je300280s.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CCCOC(C)=O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CCCOC(C)=O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.8820500000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "7f68812082a3470ba6f8cea85b9ec704",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.fluid.2008.07.001.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(=O)O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(=O)O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 1.0439000000000005
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "bcef1f7763bb4d31b4c5b59b99888804",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/je0256028.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(C)(C)O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(C)(C)O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7802700000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "9313df3b886044a498d495a45485984d",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.fluid.2009.11.030.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CCOC(=O)CC(=O)OCC{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CCOC(=O)CC(=O)OCC"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 1.0496030000000005
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "d609b0fe6fc0446f94ccf80e28204e0c",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.jct.2006.05.004.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "COC=O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "COC=O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.9668300000000004
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "6bcbbec6772046c89caec8c2cabdc203",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/je700580g.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CCCCO{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CCCCO"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.8058400000000002
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "518d22a78f3549cc8f3b7fdd7da01b59",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.tca.2012.05.004.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(C)O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(C)O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7809870000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "ca3e98a10b0d485eb2676417c01c1807",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.fluid.2008.07.001.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(C)CO{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(C)CO"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7978300000000003
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "598c36b6394142a8a1749f4d0b4b6a1d",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/acs.jced.7b00185.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CO{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CO"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7865600000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "1dcfe42a5aff48e2a8244188e5da071d",
+      "id": "75585ebb5d9f43cc95b0b69c6e4b237a",
       "phase": 2,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -554,7 +59,337 @@
     {
       "@type": "evaluator.properties.density.Density",
       "gradients": [],
-      "id": "bd9fc99565464138a3baab3be67b291f",
+      "id": "97fb93dfbce14167a7a19133588d6e43",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.tca.2012.05.004.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(C)O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(C)O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7809870000000001
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "02d887c4ffb54e50b7fe7f982ab08eeb",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.fluid.2008.07.001.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(C)CO{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(C)CO"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7978300000000003
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "c2a74deadf3d41069034352cb0f5003d",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/je700580g.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CCCCO{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CCCCO"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.8058400000000002
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "f8c4d23162e44ee3bf0d2ef56eba3be2",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.fluid.2009.11.030.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CCOC(=O)CC(=O)OCC{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CCOC(=O)CC(=O)OCC"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 1.0496030000000005
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "311107c65a97481484defee7c3b317e9",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.fluid.2008.07.001.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(=O)O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(=O)O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 1.0439000000000005
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "ef3648732d6e43e4946ceea6e53c4bbe",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/acs.jced.7b00185.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CO{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CO"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7865600000000001
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "b66593fd22c944d3906a3bfd77ae4298",
       "phase": 2,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -609,7 +444,117 @@
     {
       "@type": "evaluator.properties.density.Density",
       "gradients": [],
-      "id": "94b08446226d4ab58d2358867d930dba",
+      "id": "005ce160a6ac41e58c3b3e6f967f0b42",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/je0256028.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(C)(C)O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(C)(C)O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7802700000000001
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "07839facaf5b4eeea4274ad95b6ff45d",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.jct.2006.05.004.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "COC=O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "COC=O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.9668300000000004
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "cddaabd70d644003a38cd01e47a4ed80",
       "phase": 2,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -662,9 +607,64 @@
       }
     },
     {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "1170fb2d9dff466780cf0db7c2ae946c",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/je300280s.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CCCOC(C)=O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CCCOC(C)=O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.8820500000000001
+      }
+    },
+    {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "2e86ae298f60413a87c81f787d82a37a",
+      "id": "29b64efb08fe4b85ba92b53cfd95994e",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -713,13 +713,13 @@
       "value": {
         "@type": "evaluator.unit.Quantity",
         "unit": "kJ / mol",
-        "value": 23.36
+        "value": 51.6
       }
     },
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "df605dc0e51e4be5b95c3267bdfcb7a9",
+      "id": "8128bd8d41ed4acfa1fffe6b1fe6c4e3",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -774,7 +774,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "3fbdec009009440fa71fe97943d460e3",
+      "id": "613efbee4e5046d58f86d85ea00b8c34",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -829,7 +829,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "0ffd1860c8214f489575b80c85aa8bf9",
+      "id": "bc51d58275ed41e9a32cc4809fd121b0",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -884,7 +884,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "be9ee596945746b7bc16a5943457720d",
+      "id": "b8203b23864c496c90ff7346a05c825a",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -939,7 +939,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "c6ccca0529414dada0b1629bd8d0af47",
+      "id": "37127229370348e08f63564af58ba2bd",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -994,7 +994,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "30f38ce5181743929b9bc6c40ffc1f55",
+      "id": "20064c60953441a187cfff23332e4bf4",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1049,7 +1049,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "c7d7075e1e2a448a9d7e8519fbc37064",
+      "id": "f8cd0f404aad475eb1e523862be7338b",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1104,7 +1104,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "72a3c7f616e84f4ba58ba2770152b438",
+      "id": "92275cfe16774c7bb29be244db8be34a",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1159,7 +1159,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "085a2f91a0cf4618b8ee51ad148bf971",
+      "id": "b571eb42d5ea460a8041b5a6278d99af",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1214,7 +1214,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "36cf1d1407a94816aea6f6abe6d08907",
+      "id": "b0cc2bb7c5bd4959be0fb7c6cd722f2d",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1269,7 +1269,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "f11d041554074e41bb17a99bb9c15d45",
+      "id": "369bcdaf8853439590812b0124307c2e",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",

--- a/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_v_excess_rho_pure_h_vap/targets/mixture_data/options.json
+++ b/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_v_excess_rho_pure_h_vap/targets/mixture_data/options.json
@@ -18,7 +18,7 @@
         "EnthalpyOfVaporization": {
             "@type": "evaluator.unit.Quantity",
             "unit": "kJ / mol",
-            "value": 6.191930232165088
+            "value": 5.742931305317869
         },
         "ExcessMolarVolume": {
             "@type": "evaluator.unit.Quantity",

--- a/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_v_excess_rho_pure_h_vap/targets/mixture_data/training_set.json
+++ b/studies/mixture_feasibility/pure_mixture_optimisation/force_balance/h_mix_v_excess_rho_pure_h_vap/targets/mixture_data/training_set.json
@@ -4,502 +4,7 @@
     {
       "@type": "evaluator.properties.density.Density",
       "gradients": [],
-      "id": "ff32f758b8c54a36ba12a585ae000671",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/je300280s.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CCCOC(C)=O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CCCOC(C)=O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.8820500000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "7f68812082a3470ba6f8cea85b9ec704",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.fluid.2008.07.001.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(=O)O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(=O)O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 1.0439000000000005
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "bcef1f7763bb4d31b4c5b59b99888804",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/je0256028.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(C)(C)O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(C)(C)O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7802700000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "9313df3b886044a498d495a45485984d",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.fluid.2009.11.030.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CCOC(=O)CC(=O)OCC{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CCOC(=O)CC(=O)OCC"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 1.0496030000000005
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "d609b0fe6fc0446f94ccf80e28204e0c",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.jct.2006.05.004.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "COC=O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "COC=O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.9668300000000004
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "6bcbbec6772046c89caec8c2cabdc203",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/je700580g.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CCCCO{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CCCCO"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.8058400000000002
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "518d22a78f3549cc8f3b7fdd7da01b59",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.tca.2012.05.004.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(C)O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(C)O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7809870000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "ca3e98a10b0d485eb2676417c01c1807",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.fluid.2008.07.001.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(C)CO{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(C)CO"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7978300000000003
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "598c36b6394142a8a1749f4d0b4b6a1d",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/acs.jced.7b00185.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CO{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CO"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7865600000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "1dcfe42a5aff48e2a8244188e5da071d",
+      "id": "75585ebb5d9f43cc95b0b69c6e4b237a",
       "phase": 2,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -554,7 +59,337 @@
     {
       "@type": "evaluator.properties.density.Density",
       "gradients": [],
-      "id": "bd9fc99565464138a3baab3be67b291f",
+      "id": "97fb93dfbce14167a7a19133588d6e43",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.tca.2012.05.004.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(C)O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(C)O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7809870000000001
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "02d887c4ffb54e50b7fe7f982ab08eeb",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.fluid.2008.07.001.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(C)CO{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(C)CO"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7978300000000003
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "c2a74deadf3d41069034352cb0f5003d",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/je700580g.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CCCCO{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CCCCO"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.8058400000000002
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "f8c4d23162e44ee3bf0d2ef56eba3be2",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.fluid.2009.11.030.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CCOC(=O)CC(=O)OCC{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CCOC(=O)CC(=O)OCC"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 1.0496030000000005
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "311107c65a97481484defee7c3b317e9",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.fluid.2008.07.001.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(=O)O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(=O)O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 1.0439000000000005
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "ef3648732d6e43e4946ceea6e53c4bbe",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/acs.jced.7b00185.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CO{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CO"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7865600000000001
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "b66593fd22c944d3906a3bfd77ae4298",
       "phase": 2,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -609,7 +444,117 @@
     {
       "@type": "evaluator.properties.density.Density",
       "gradients": [],
-      "id": "94b08446226d4ab58d2358867d930dba",
+      "id": "005ce160a6ac41e58c3b3e6f967f0b42",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/je0256028.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(C)(C)O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(C)(C)O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7802700000000001
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "07839facaf5b4eeea4274ad95b6ff45d",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.jct.2006.05.004.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "COC=O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "COC=O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.9668300000000004
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "cddaabd70d644003a38cd01e47a4ed80",
       "phase": 2,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -662,9 +607,64 @@
       }
     },
     {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "1170fb2d9dff466780cf0db7c2ae946c",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/je300280s.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CCCOC(C)=O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CCCOC(C)=O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.8820500000000001
+      }
+    },
+    {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "2e86ae298f60413a87c81f787d82a37a",
+      "id": "29b64efb08fe4b85ba92b53cfd95994e",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -713,13 +713,13 @@
       "value": {
         "@type": "evaluator.unit.Quantity",
         "unit": "kJ / mol",
-        "value": 23.36
+        "value": 51.6
       }
     },
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "df605dc0e51e4be5b95c3267bdfcb7a9",
+      "id": "8128bd8d41ed4acfa1fffe6b1fe6c4e3",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -774,7 +774,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "3fbdec009009440fa71fe97943d460e3",
+      "id": "613efbee4e5046d58f86d85ea00b8c34",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -829,7 +829,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "0ffd1860c8214f489575b80c85aa8bf9",
+      "id": "bc51d58275ed41e9a32cc4809fd121b0",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -884,7 +884,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "be9ee596945746b7bc16a5943457720d",
+      "id": "b8203b23864c496c90ff7346a05c825a",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -939,7 +939,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "c6ccca0529414dada0b1629bd8d0af47",
+      "id": "37127229370348e08f63564af58ba2bd",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -994,7 +994,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "30f38ce5181743929b9bc6c40ffc1f55",
+      "id": "20064c60953441a187cfff23332e4bf4",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1049,7 +1049,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "c7d7075e1e2a448a9d7e8519fbc37064",
+      "id": "f8cd0f404aad475eb1e523862be7338b",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1104,7 +1104,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "72a3c7f616e84f4ba58ba2770152b438",
+      "id": "92275cfe16774c7bb29be244db8be34a",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1159,7 +1159,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "085a2f91a0cf4618b8ee51ad148bf971",
+      "id": "b571eb42d5ea460a8041b5a6278d99af",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1214,7 +1214,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "36cf1d1407a94816aea6f6abe6d08907",
+      "id": "b0cc2bb7c5bd4959be0fb7c6cd722f2d",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1269,7 +1269,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "f11d041554074e41bb17a99bb9c15d45",
+      "id": "369bcdaf8853439590812b0124307c2e",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",

--- a/studies/mixture_feasibility/pure_optimisation/data_set_generation/build_hvap_set.py
+++ b/studies/mixture_feasibility/pure_optimisation/data_set_generation/build_hvap_set.py
@@ -20,8 +20,8 @@ def main():
             ),
             phase=h_vap_phase,
             substance=Substance.from_components("OC=O"),
-            value=20.1 * unit.kilojoule / unit.mole,
-            uncertainty=0.02 * unit.kilojoule / unit.mole,
+            value=46.3 * unit.kilojoule / unit.mole,
+            uncertainty=0.25 * unit.kilojoule / unit.mole,
             source=MeasurementSource(doi="10.3891/acta.chem.scand.24-2612"),
         ),
         # Acetic Acid
@@ -31,8 +31,8 @@ def main():
             ),
             phase=h_vap_phase,
             substance=Substance.from_components("CC(O)=O"),
-            value=23.36 * unit.kilojoule / unit.mole,
-            uncertainty=0.05 * unit.kilojoule / unit.mole,
+            value=51.6 * unit.kilojoule / unit.mole,
+            uncertainty=0.75 * unit.kilojoule / unit.mole,
             source=MeasurementSource(doi="10.3891/acta.chem.scand.24-2612"),
         ),
         # Propionic Acid
@@ -42,8 +42,8 @@ def main():
             ),
             phase=h_vap_phase,
             substance=Substance.from_components("CCC(O)=O"),
-            value=31.14 * unit.kilojoule / unit.mole,
-            uncertainty=0.01 * unit.kilojoule / unit.mole,
+            value=55 * unit.kilojoule / unit.mole,
+            uncertainty=1 * unit.kilojoule / unit.mole,
             source=MeasurementSource(doi="10.3891/acta.chem.scand.24-2612"),
         ),
         # Butyric Acid
@@ -53,8 +53,8 @@ def main():
             ),
             phase=h_vap_phase,
             substance=Substance.from_components("CCCC(O)=O"),
-            value=40.45 * unit.kilojoule / unit.mole,
-            uncertainty=0.03 * unit.kilojoule / unit.mole,
+            value=58 * unit.kilojoule / unit.mole,
+            uncertainty=2 * unit.kilojoule / unit.mole,
             source=MeasurementSource(doi="10.3891/acta.chem.scand.24-2612"),
         ),
         # Isobutyric Acid
@@ -64,19 +64,8 @@ def main():
             ),
             phase=h_vap_phase,
             substance=Substance.from_components("CC(C)C(O)=O"),
-            value=35.3 * unit.kilojoule / unit.mole,
-            uncertainty=0.04 * unit.kilojoule / unit.mole,
-            source=MeasurementSource(doi="10.3891/acta.chem.scand.24-2612"),
-        ),
-        # Isovaleric Acid
-        EnthalpyOfVaporization(
-            thermodynamic_state=ThermodynamicState(
-                temperature=298.15 * unit.kelvin, pressure=1.0 * unit.atmosphere
-            ),
-            phase=h_vap_phase,
-            substance=Substance.from_components("CC(C)CC(O)=O"),
-            value=46.91 * unit.kilojoule / unit.mole,
-            uncertainty=0.09 * unit.kilojoule / unit.mole,
+            value=53 * unit.kilojoule / unit.mole,
+            uncertainty=2 * unit.kilojoule / unit.mole,
             source=MeasurementSource(doi="10.3891/acta.chem.scand.24-2612"),
         ),
         # Water

--- a/studies/mixture_feasibility/pure_optimisation/force_balance/targets/pure_data/options.json
+++ b/studies/mixture_feasibility/pure_optimisation/force_balance/targets/pure_data/options.json
@@ -13,7 +13,7 @@
         "EnthalpyOfVaporization": {
             "@type": "evaluator.unit.Quantity",
             "unit": "kJ / mol",
-            "value": 6.191930232165088
+            "value": 5.742931305317869
         }
     },
     "estimation_options": {

--- a/studies/mixture_feasibility/pure_optimisation/force_balance/targets/pure_data/training_set.json
+++ b/studies/mixture_feasibility/pure_optimisation/force_balance/targets/pure_data/training_set.json
@@ -4,502 +4,7 @@
     {
       "@type": "evaluator.properties.density.Density",
       "gradients": [],
-      "id": "ff32f758b8c54a36ba12a585ae000671",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/je300280s.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CCCOC(C)=O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CCCOC(C)=O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.8820500000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "7f68812082a3470ba6f8cea85b9ec704",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.fluid.2008.07.001.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(=O)O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(=O)O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 1.0439000000000005
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "bcef1f7763bb4d31b4c5b59b99888804",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/je0256028.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(C)(C)O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(C)(C)O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7802700000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "9313df3b886044a498d495a45485984d",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.fluid.2009.11.030.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CCOC(=O)CC(=O)OCC{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CCOC(=O)CC(=O)OCC"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 1.0496030000000005
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "d609b0fe6fc0446f94ccf80e28204e0c",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.jct.2006.05.004.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "COC=O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "COC=O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.9668300000000004
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "6bcbbec6772046c89caec8c2cabdc203",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/je700580g.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CCCCO{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CCCCO"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.8058400000000002
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "518d22a78f3549cc8f3b7fdd7da01b59",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.tca.2012.05.004.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(C)O{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(C)O"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7809870000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "ca3e98a10b0d485eb2676417c01c1807",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/j.fluid.2008.07.001.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CC(C)CO{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CC(C)CO"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7978300000000003
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "598c36b6394142a8a1749f4d0b4b6a1d",
-      "phase": 2,
-      "source": {
-        "@type": "evaluator.datasets.provenance.MeasurementSource",
-        "doi": "",
-        "reference": "raw_archives/acs.jced.7b00185.xml"
-      },
-      "substance": {
-        "@type": "evaluator.substances.substances.Substance",
-        "amounts": {
-          "CO{solv}": [
-            {
-              "@type": "evaluator.substances.amounts.MoleFraction",
-              "value": 1.0
-            }
-          ]
-        },
-        "components": [
-          {
-            "@type": "evaluator.substances.components.Component",
-            "role": {
-              "@type": "evaluator.substances.components.Component.Role",
-              "value": "solv"
-            },
-            "smiles": "CO"
-          }
-        ]
-      },
-      "thermodynamic_state": {
-        "@type": "evaluator.thermodynamics.ThermodynamicState",
-        "pressure": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "kPa",
-          "value": 101.325
-        },
-        "temperature": {
-          "@type": "evaluator.unit.Quantity",
-          "unit": "K",
-          "value": 298.15
-        }
-      },
-      "uncertainty": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.0
-      },
-      "value": {
-        "@type": "evaluator.unit.Quantity",
-        "unit": "g / ml",
-        "value": 0.7865600000000001
-      }
-    },
-    {
-      "@type": "evaluator.properties.density.Density",
-      "gradients": [],
-      "id": "1dcfe42a5aff48e2a8244188e5da071d",
+      "id": "75585ebb5d9f43cc95b0b69c6e4b237a",
       "phase": 2,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -554,7 +59,337 @@
     {
       "@type": "evaluator.properties.density.Density",
       "gradients": [],
-      "id": "bd9fc99565464138a3baab3be67b291f",
+      "id": "97fb93dfbce14167a7a19133588d6e43",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.tca.2012.05.004.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(C)O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(C)O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7809870000000001
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "02d887c4ffb54e50b7fe7f982ab08eeb",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.fluid.2008.07.001.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(C)CO{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(C)CO"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7978300000000003
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "c2a74deadf3d41069034352cb0f5003d",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/je700580g.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CCCCO{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CCCCO"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.8058400000000002
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "f8c4d23162e44ee3bf0d2ef56eba3be2",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.fluid.2009.11.030.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CCOC(=O)CC(=O)OCC{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CCOC(=O)CC(=O)OCC"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 1.0496030000000005
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "311107c65a97481484defee7c3b317e9",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.fluid.2008.07.001.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(=O)O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(=O)O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 1.0439000000000005
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "ef3648732d6e43e4946ceea6e53c4bbe",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/acs.jced.7b00185.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CO{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CO"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7865600000000001
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "b66593fd22c944d3906a3bfd77ae4298",
       "phase": 2,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -609,7 +444,117 @@
     {
       "@type": "evaluator.properties.density.Density",
       "gradients": [],
-      "id": "94b08446226d4ab58d2358867d930dba",
+      "id": "005ce160a6ac41e58c3b3e6f967f0b42",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/je0256028.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CC(C)(C)O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CC(C)(C)O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.7802700000000001
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "07839facaf5b4eeea4274ad95b6ff45d",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/j.jct.2006.05.004.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "COC=O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "COC=O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.9668300000000004
+      }
+    },
+    {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "cddaabd70d644003a38cd01e47a4ed80",
       "phase": 2,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -662,9 +607,64 @@
       }
     },
     {
+      "@type": "evaluator.properties.density.Density",
+      "gradients": [],
+      "id": "1170fb2d9dff466780cf0db7c2ae946c",
+      "phase": 2,
+      "source": {
+        "@type": "evaluator.datasets.provenance.MeasurementSource",
+        "doi": "",
+        "reference": "raw_archives/je300280s.xml"
+      },
+      "substance": {
+        "@type": "evaluator.substances.substances.Substance",
+        "amounts": {
+          "CCCOC(C)=O{solv}": [
+            {
+              "@type": "evaluator.substances.amounts.MoleFraction",
+              "value": 1.0
+            }
+          ]
+        },
+        "components": [
+          {
+            "@type": "evaluator.substances.components.Component",
+            "role": {
+              "@type": "evaluator.substances.components.Component.Role",
+              "value": "solv"
+            },
+            "smiles": "CCCOC(C)=O"
+          }
+        ]
+      },
+      "thermodynamic_state": {
+        "@type": "evaluator.thermodynamics.ThermodynamicState",
+        "pressure": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "kPa",
+          "value": 101.325
+        },
+        "temperature": {
+          "@type": "evaluator.unit.Quantity",
+          "unit": "K",
+          "value": 298.15
+        }
+      },
+      "uncertainty": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.0
+      },
+      "value": {
+        "@type": "evaluator.unit.Quantity",
+        "unit": "g / ml",
+        "value": 0.8820500000000001
+      }
+    },
+    {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "2e86ae298f60413a87c81f787d82a37a",
+      "id": "29b64efb08fe4b85ba92b53cfd95994e",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -713,13 +713,13 @@
       "value": {
         "@type": "evaluator.unit.Quantity",
         "unit": "kJ / mol",
-        "value": 23.36
+        "value": 51.6
       }
     },
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "df605dc0e51e4be5b95c3267bdfcb7a9",
+      "id": "8128bd8d41ed4acfa1fffe6b1fe6c4e3",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -774,7 +774,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "3fbdec009009440fa71fe97943d460e3",
+      "id": "613efbee4e5046d58f86d85ea00b8c34",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -829,7 +829,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "0ffd1860c8214f489575b80c85aa8bf9",
+      "id": "bc51d58275ed41e9a32cc4809fd121b0",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -884,7 +884,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "be9ee596945746b7bc16a5943457720d",
+      "id": "b8203b23864c496c90ff7346a05c825a",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -939,7 +939,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "c6ccca0529414dada0b1629bd8d0af47",
+      "id": "37127229370348e08f63564af58ba2bd",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -994,7 +994,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "30f38ce5181743929b9bc6c40ffc1f55",
+      "id": "20064c60953441a187cfff23332e4bf4",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1049,7 +1049,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "c7d7075e1e2a448a9d7e8519fbc37064",
+      "id": "f8cd0f404aad475eb1e523862be7338b",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1104,7 +1104,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "72a3c7f616e84f4ba58ba2770152b438",
+      "id": "92275cfe16774c7bb29be244db8be34a",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1159,7 +1159,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "085a2f91a0cf4618b8ee51ad148bf971",
+      "id": "b571eb42d5ea460a8041b5a6278d99af",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1214,7 +1214,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "36cf1d1407a94816aea6f6abe6d08907",
+      "id": "b0cc2bb7c5bd4959be0fb7c6cd722f2d",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",
@@ -1269,7 +1269,7 @@
     {
       "@type": "evaluator.properties.enthalpy.EnthalpyOfVaporization",
       "gradients": [],
-      "id": "f11d041554074e41bb17a99bb9c15d45",
+      "id": "369bcdaf8853439590812b0124307c2e",
       "phase": 6,
       "source": {
         "@type": "evaluator.datasets.provenance.MeasurementSource",


### PR DESCRIPTION
## Description

This PR aims to correct the literature sourced Hvap values for the series of acids. The current values correspond to the enthalpy difference between a saturated vapour and the liquid, rather than an infinitely dilute gas and the liquid (i.e the standard state) [1]:

![IUPAC_quote](https://user-images.githubusercontent.com/22272126/75907378-6a54a100-5e05-11ea-92f4-af642bafae01.jpg)

Here we change the data to be the corrected values at the standard state, sourced from Table 2. of [10.3891/acta.chem.scand.24-2612](http://actachemscand.org/doi/10.3891/acta.chem.scand.24-2612) [2]

## References

[1] Majer V, Svoboda V, editors. Enthalpies of Vaporization of Organic Compounds: A Critical Review and Data Compilation. Blackwell Scientific Publications; Oxford: 1985. pp. 1–304.

[2] Konicek J, Wadso I. Enthalpies of Vaporization of Organic Compounds .7. Some Carboxylic Acids. Acta Chem. Scand. 1970;24:2612–2626.

## Status
- [X] Ready to go