### PR TITLE
[Mixture] Phase 1 Benchmark Set Curation

### DIFF
--- a/nistdataselection/curation/filtering.py
+++ b/nistdataselection/curation/filtering.py
@@ -357,6 +357,8 @@ def filter_by_smiles(
 
         if any(x in smiles_to_exclude for x in component_smiles):
             return False
+        elif len(smiles_to_exclude) > 0:
+            return True
 
         if not allow_partial_inclusion and not all(
             x in smiles_to_include for x in component_smiles

--- a/nistdataselection/curation/selection.py
+++ b/nistdataselection/curation/selection.py
@@ -566,8 +566,9 @@ def select_data_points(data_directory, chosen_substances, target_state_points):
     data_directory: str
         The directory which contains the processed pandas
         data sets
-    chosen_substances: list of tuple of str
-        The substances to choose data points for.
+    chosen_substances: list of tuple of str, optional
+        The substances to choose data points for. If None,
+        no filtering of substances will be performed by this function.
     target_state_points: dict of tuple of type and SubstanceType and list of StatePoint
         A list of the state points for which we would ideally have data
         points for. The value tuple should be of the form
@@ -602,7 +603,7 @@ def select_data_points(data_directory, chosen_substances, target_state_points):
             sorted([component.smiles for component in substance.components])
         )
 
-        if substance_tuple not in chosen_substances:
+        if chosen_substances is not None and substance_tuple not in chosen_substances:
             continue
 
         properties_by_substance[substance_tuple].extend(

--- a/nistdataselection/utils/pandas.py
+++ b/nistdataselection/utils/pandas.py
@@ -154,7 +154,7 @@ def data_frame_to_smiles_tuples(data_frame):
     list of tuple of str
         The smiles patterns of the measured substances.
     """
-    n_components = data_frame[f"N Components"].max()
+    n_components = int(data_frame[f"N Components"].max())
 
     all_smiles = [
         data_frame[f"Component {i + 1}"].tolist() for i in range(n_components)

--- a/nistdataselection/utils/utils.py
+++ b/nistdataselection/utils/utils.py
@@ -281,6 +281,9 @@ def data_frame_to_pdf(data_frame, file_path, rows=10, columns=6):
         The maximum number of molecules to include per row.
     """
 
+    if len(data_frame) == 0:
+        return
+
     smiles_tuples = data_frame_to_smiles_tuples(data_frame)
     smiles_to_pdf(smiles_tuples, file_path, rows, columns)
 

--- a/studies/mixture_feasibility/benchmark_selection/build_test_set.py
+++ b/studies/mixture_feasibility/benchmark_selection/build_test_set.py
@@ -1,0 +1,234 @@
+"""A script to filter out all of the training set
+compounds from the available data.
+"""
+import functools
+import os
+from collections import defaultdict
+
+import pandas
+from evaluator import unit
+from evaluator.datasets import PhysicalPropertyDataSet
+from evaluator.properties import Density, EnthalpyOfMixing, ExcessMolarVolume
+
+from nistdataselection.curation.filtering import (
+    filter_by_smiles,
+    filter_by_substance_composition,
+    filter_by_temperature,
+)
+from nistdataselection.curation.selection import StatePoint, select_data_points
+from nistdataselection.processing import (
+    load_processed_data_set,
+    save_processed_data_set,
+)
+from nistdataselection.utils import SubstanceType, data_set_from_data_frame
+from nistdataselection.utils.utils import data_frame_to_pdf
+
+
+def build_pure_set(pure_training_set_smiles):
+
+    # Load in the Hvap data
+    h_vap_data_frame = pandas.read_csv(
+        os.path.join(
+            "..", "data_availability", "sourced_h_vap_data", "alcohol_ester_h_vap.csv"
+        )
+    )
+    h_vap_data_frame = filter_by_smiles(
+        h_vap_data_frame,
+        smiles_to_include=None,
+        smiles_to_exclude=pure_training_set_smiles,
+    )
+
+    h_vap_data_set = data_set_from_data_frame(h_vap_data_frame)
+
+    # Pull out the chosen smiles patterns
+    chosen_smiles = [*h_vap_data_frame["Component 1"]]
+
+    # # Load in the density data
+    density_data_frame = pandas.read_csv(
+        os.path.join(
+            "..", "data_availability", "all_alcohol_ester_data", "density_pure.csv"
+        )
+    )
+    density_data_frame = filter_by_smiles(
+        density_data_frame, smiles_to_include=chosen_smiles, smiles_to_exclude=None
+    )
+
+    density_data_set = data_set_from_data_frame(density_data_frame)
+
+    # Retain the density measurements which were made closest to 298.15K and 1 atm.
+    target_state_point = StatePoint(
+        temperature=298.15 * unit.kelvin,
+        pressure=1.0 * unit.atmosphere,
+        mole_fractions=(1.0,),
+    )
+
+    final_data_set = PhysicalPropertyDataSet()
+
+    for substance in density_data_set.substances:
+
+        properties_per_state = defaultdict(list)
+
+        # Refactor the properties into more convenient data structures.
+        for physical_property in density_data_set.properties_by_substance(substance):
+
+            state_point = StatePoint.from_physical_property(physical_property)
+            properties_per_state[state_point].append(physical_property)
+
+        # Sort the state points based on their distance to the target state.
+        sorted_states_points = list(
+            sorted(
+                properties_per_state.keys(),
+                key=functools.partial(
+                    StatePoint.individual_distances, target_state_point
+                ),
+            )
+        )
+
+        final_data_set.add_properties(properties_per_state[sorted_states_points[0]][0])
+
+    final_data_set.merge(h_vap_data_set)
+
+    return final_data_set
+
+
+def filter_common_data(mixture_training_set_smiles, output_directory):
+    """Filter the common data to a smaller temperature range - this
+    seems to help the state selection method get closer to the target
+    states.
+    """
+    os.makedirs(os.path.join(output_directory), exist_ok=True)
+
+    for property_type, substance_type in [
+        (EnthalpyOfMixing, SubstanceType.Binary),
+        (ExcessMolarVolume, SubstanceType.Binary),
+        (Density, SubstanceType.Binary),
+    ]:
+
+        folder_name = (
+            "h_mix_and_v_excess"
+            if property_type != Density
+            else "h_mix_and_binary_density"
+        )
+
+        data_frame = load_processed_data_set(
+            os.path.join("..", "data_availability", "common_data", folder_name),
+            property_type,
+            substance_type,
+        )
+        data_frame = filter_by_temperature(
+            data_frame, 290.0 * unit.kelvin, 305 * unit.kelvin
+        )
+        data_frame = filter_by_substance_composition(
+            data_frame, None, mixture_training_set_smiles
+        )
+
+        save_processed_data_set(
+            output_directory, data_frame, property_type, substance_type,
+        )
+
+
+def build_mixture_set(mixture_training_set_smiles):
+
+    target_states = [
+        StatePoint(298.15 * unit.kelvin, 1.0 * unit.atmosphere, (0.25, 0.75)),
+        StatePoint(298.15 * unit.kelvin, 1.0 * unit.atmosphere, (0.50, 0.50)),
+        StatePoint(298.15 * unit.kelvin, 1.0 * unit.atmosphere, (0.75, 0.25)),
+    ]
+
+    filtered_directory = "filtered_mixture_data"
+    filter_common_data(mixture_training_set_smiles, filtered_directory)
+
+    output_directory = "training_sets"
+    os.makedirs(output_directory, exist_ok=True)
+
+    mixture_set = select_data_points(
+        data_directory=filtered_directory,
+        chosen_substances=None,
+        target_state_points={
+            (EnthalpyOfMixing, SubstanceType.Binary): target_states,
+            (ExcessMolarVolume, SubstanceType.Binary): target_states,
+            (Density, SubstanceType.Binary): target_states,
+        },
+    )
+
+    return mixture_set
+
+
+def main():
+
+    output_directory = "selected_sets"
+    os.makedirs(output_directory, exist_ok=True)
+
+    # Determine which compounds were used during training.
+    h_mix_v_excess_set = PhysicalPropertyDataSet.from_json(
+        os.path.join(
+            "..",
+            "pure_mixture_optimisation",
+            "force_balance",
+            "h_mix_v_excess_rho_pure_h_vap",
+            "targets",
+            "mixture_data",
+            "training_set.json",
+        )
+    )
+    h_mix_rho_x_set = PhysicalPropertyDataSet.from_json(
+        os.path.join(
+            "..",
+            "pure_mixture_optimisation",
+            "force_balance",
+            "h_mix_rho_x_rho_pure_h_vap",
+            "targets",
+            "mixture_data",
+            "training_set.json",
+        )
+    )
+
+    all_substance_smiles = [
+        *((x.smiles for x in y) for y in h_mix_v_excess_set.substances),
+        *((x.smiles for x in y) for y in h_mix_rho_x_set.substances),
+    ]
+    all_substance_smiles = [tuple(sorted(x)) for x in all_substance_smiles]
+
+    unique_substance_smiles = set(all_substance_smiles)
+
+    pure_substance_smiles = [x for x in unique_substance_smiles if len(x) == 1]
+    binary_substance_smiles = [x for x in unique_substance_smiles if len(x) == 2]
+
+    # Select a pure test set
+    pure_test_set = build_pure_set(pure_substance_smiles)
+    pure_test_set.json(os.path.join(output_directory, "pure_set.json"))
+
+    pure_test_pandas = pure_test_set.to_pandas()
+
+    pure_test_pandas.to_csv(os.path.join(output_directory, "pure_set.csv"), index=False)
+    data_frame_to_pdf(
+        pure_test_pandas, os.path.join(output_directory, "pure_set.pdf"),
+    )
+
+    # Select a mixture test set
+    mixture_test_set = build_mixture_set(binary_substance_smiles)
+    mixture_test_set.json(os.path.join(output_directory, "mixture_set.json"))
+
+    mixture_test_pandas = mixture_test_set.to_pandas()
+
+    mixture_test_pandas.to_csv(
+        os.path.join(output_directory, "mixture_set.csv"), index=False
+    )
+    data_frame_to_pdf(
+        mixture_test_pandas, os.path.join(output_directory, "mixture_set.pdf"),
+    )
+
+    # Combine the two sets
+    full_data_set = PhysicalPropertyDataSet()
+    full_data_set.merge(pure_test_set)
+    full_data_set.merge(mixture_test_set)
+
+    full_data_set.json(os.path.join(output_directory, "full_set.json"))
+
+    full_set_pandas = full_data_set.to_pandas()
+
+    full_set_pandas.to_csv(os.path.join(output_directory, "full_set.csv"), index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/studies/mixture_feasibility/benchmark_selection/filter_mixture_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/filter_mixture_data.py
@@ -64,7 +64,7 @@ def main():
     ]
     training_smiles = set(tuple(sorted(x)) for x in training_smiles)
 
-    for pair_types in ["alcohol_alcohol", "alcohol_ester"]:
+    for pair_types in ["alcohol_alcohol", "alcohol_ester", "ester_ester"]:
 
         pair_directory = os.path.join(output_directory, pair_types)
         os.makedirs(pair_directory, exist_ok=True)

--- a/studies/mixture_feasibility/benchmark_selection/filter_mixture_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/filter_mixture_data.py
@@ -1,0 +1,122 @@
+"""A script which will filter the available mixture data
+so that
+
+* no training mixtures appear in the test sets.
+* only data measured at conditions close to ambient is retained
+* longer chain molecules / aromatics are removed.
+
+Currently we filter out some of the longer molecules, aromatics,
+and molecules containing moieties not trained against to allow
+the construction of a smaller, more focused initial benchmark
+set.
+"""
+import os
+
+from evaluator import unit
+from evaluator.datasets import PhysicalPropertyDataSet
+from evaluator.properties import Density, EnthalpyOfMixing, ExcessMolarVolume
+
+from nistdataselection.curation.filtering import (
+    filter_by_smirks,
+    filter_by_substance_composition,
+    filter_by_temperature,
+)
+from nistdataselection.processing import (
+    load_processed_data_set,
+    save_processed_data_set,
+)
+from nistdataselection.utils import SubstanceType
+from nistdataselection.utils.utils import data_frame_to_pdf, property_to_snake_case
+
+
+def main():
+
+    output_directory = "filtered_data"
+    os.makedirs(output_directory, exist_ok=True)
+
+    # Determine which compounds were used during training.
+    h_mix_v_excess_set = PhysicalPropertyDataSet.from_json(
+        os.path.join(
+            "..",
+            "mixture_optimisation",
+            "force_balance",
+            "h_mix_binary_density",
+            "targets",
+            "mixture_data",
+            "training_set.json",
+        )
+    )
+    h_mix_rho_x_set = PhysicalPropertyDataSet.from_json(
+        os.path.join(
+            "..",
+            "mixture_optimisation",
+            "force_balance",
+            "h_mix_v_excess",
+            "targets",
+            "mixture_data",
+            "training_set.json",
+        )
+    )
+
+    training_smiles = [
+        *((x.smiles for x in y) for y in h_mix_v_excess_set.substances),
+        *((x.smiles for x in y) for y in h_mix_rho_x_set.substances),
+    ]
+    training_smiles = set(tuple(sorted(x)) for x in training_smiles)
+
+    for pair_types in ["alcohol_alcohol", "alcohol_ester"]:
+
+        pair_directory = os.path.join(output_directory, pair_types)
+        os.makedirs(pair_directory, exist_ok=True)
+
+        for property_type, substance_type in [
+            (EnthalpyOfMixing, SubstanceType.Binary),
+            (ExcessMolarVolume, SubstanceType.Binary),
+            (Density, SubstanceType.Binary),
+        ]:
+
+            # Load in the data set
+            folder_name = f"all_{pair_types}_data"
+
+            data_frame = load_processed_data_set(
+                os.path.join("..", "data_availability", folder_name),
+                property_type,
+                substance_type,
+            )
+
+            # Filter to be close to ambient.
+            data_frame = filter_by_temperature(
+                data_frame, 290.0 * unit.kelvin, 305 * unit.kelvin
+            )
+            # Filter out the training set
+            data_frame = filter_by_substance_composition(
+                data_frame, None, training_smiles
+            )
+            # Filter out aromatics, long chain molecules (>= hept), alkenes,
+            # ethers, 3 + 4 membered rings
+            data_frame = filter_by_smirks(
+                data_frame,
+                None,
+                [
+                    "[#6a]",
+                    "[#6r3]",
+                    "[#6r4]",
+                    "[#6]=[#6]",
+                    "[#6]~[#6]~[#6]~[#6]~[#6]~[#6]~[#6]",
+                    "[#6H2]-[#8X2]-[#6H2]",
+                ],
+            )
+
+            # Save the filtered set.
+            save_processed_data_set(
+                pair_directory, data_frame, property_type, substance_type,
+            )
+
+            property_type = property_to_snake_case(property_type)
+            file_name = f"{property_type}_{str(substance_type.value)}.pdf"
+
+            data_frame_to_pdf(data_frame, os.path.join(pair_directory, file_name))
+
+
+if __name__ == "__main__":
+    main()

--- a/studies/mixture_feasibility/benchmark_selection/filter_pure_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/filter_pure_data.py
@@ -1,0 +1,73 @@
+"""A script to filter out all of the training set
+compounds from the available pure data.
+"""
+import os
+
+import pandas
+from evaluator.datasets import PhysicalPropertyDataSet
+from evaluator.properties import Density, EnthalpyOfVaporization
+
+from nistdataselection.curation.filtering import filter_by_smiles
+from nistdataselection.processing import save_processed_data_set
+from nistdataselection.utils import SubstanceType
+from nistdataselection.utils.utils import data_frame_to_pdf
+
+
+def main():
+
+    output_directory = "filtered_data"
+    os.makedirs(output_directory, exist_ok=True)
+
+    # Determine which compounds were used during training.
+    pure_training_set = PhysicalPropertyDataSet.from_json(
+        os.path.join(
+            "..",
+            "pure_optimisation",
+            "force_balance",
+            "targets",
+            "pure_data",
+            "training_set.json",
+        )
+    )
+
+    training_smiles = set(x.smiles for y in pure_training_set.substances for x in y)
+
+    # Load in the Hvap data
+    h_vap_data_frame = pandas.read_csv(
+        os.path.join(
+            "..", "data_availability", "sourced_h_vap_data", "alcohol_ester_h_vap.csv"
+        )
+    )
+    h_vap_data_frame = filter_by_smiles(
+        h_vap_data_frame, smiles_to_include=None, smiles_to_exclude=training_smiles,
+    )
+    save_processed_data_set(
+        output_directory, h_vap_data_frame, EnthalpyOfVaporization, SubstanceType.Pure,
+    )
+    data_frame_to_pdf(
+        h_vap_data_frame,
+        os.path.join(output_directory, "enthalpy_of_vaporization_pure.pdf"),
+    )
+
+    # Pull out the smiles patterns for which there exists Hvap data.
+    test_smiles = [*h_vap_data_frame["Component 1"]]
+
+    # Load in the density data
+    density_data_frame = pandas.read_csv(
+        os.path.join(
+            "..", "data_availability", "all_alcohol_ester_data", "density_pure.csv"
+        )
+    )
+    density_data_frame = filter_by_smiles(
+        density_data_frame, smiles_to_include=test_smiles, smiles_to_exclude=None
+    )
+    save_processed_data_set(
+        output_directory, density_data_frame, Density, SubstanceType.Pure,
+    )
+    data_frame_to_pdf(
+        h_vap_data_frame, os.path.join(output_directory, "density_pure.pdf")
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/studies/mixture_feasibility/benchmark_selection/partition_alcohol_ester_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/partition_alcohol_ester_data.py
@@ -17,6 +17,8 @@ from nistdataselection.utils.utils import data_frame_to_pdf, property_to_snake_c
 chemical_environment_codes = {
     "caboxylic_acid": "076",
     "ester": "078",
+    "hydroxy": "027",
+    "alcohol": "028",
 }
 
 
@@ -38,6 +40,8 @@ def main():
     pure_alcohol_set = filter_by_checkmol(
         pure_training_set.to_pandas(),
         [
+            chemical_environment_codes["hydroxy"],
+            chemical_environment_codes["alcohol"],
             chemical_environment_codes["caboxylic_acid"],
             chemical_environment_codes["ester"],
         ],
@@ -72,12 +76,9 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-
-        if len(data_frame) > 0:
-
-            data_frame_to_pdf(
-                data_frame, os.path.join(base_directory, file_name + ".pdf")
-            )
+        data_frame_to_pdf(
+            data_frame, os.path.join(base_directory, file_name + ".pdf")
+        )
 
         # Extract properties where only one component appears in
         # in the training set.
@@ -96,12 +97,9 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-
-        if len(data_frame) > 0:
-
-            data_frame_to_pdf(
-                data_frame, os.path.join(base_directory, file_name + ".pdf")
-            )
+        data_frame_to_pdf(
+            data_frame, os.path.join(base_directory, file_name + ".pdf")
+        )
 
         # Extract properties where neither component appears in
         # in the training set.
@@ -114,12 +112,9 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-
-        if len(data_frame) > 0:
-
-            data_frame_to_pdf(
-                data_frame, os.path.join(base_directory, file_name + ".pdf")
-            )
+        data_frame_to_pdf(
+            data_frame, os.path.join(base_directory, file_name + ".pdf")
+        )
 
 
 if __name__ == "__main__":

--- a/studies/mixture_feasibility/benchmark_selection/partition_alcohol_ester_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/partition_alcohol_ester_data.py
@@ -76,9 +76,7 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-        data_frame_to_pdf(
-            data_frame, os.path.join(base_directory, file_name + ".pdf")
-        )
+        data_frame_to_pdf(data_frame, os.path.join(base_directory, file_name + ".pdf"))
 
         # Extract properties where only one component appears in
         # in the training set.
@@ -97,9 +95,7 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-        data_frame_to_pdf(
-            data_frame, os.path.join(base_directory, file_name + ".pdf")
-        )
+        data_frame_to_pdf(data_frame, os.path.join(base_directory, file_name + ".pdf"))
 
         # Extract properties where neither component appears in
         # in the training set.
@@ -112,9 +108,7 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-        data_frame_to_pdf(
-            data_frame, os.path.join(base_directory, file_name + ".pdf")
-        )
+        data_frame_to_pdf(data_frame, os.path.join(base_directory, file_name + ".pdf"))
 
 
 if __name__ == "__main__":

--- a/studies/mixture_feasibility/benchmark_selection/partition_alcohol_ester_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/partition_alcohol_ester_data.py
@@ -1,0 +1,126 @@
+"""This script partitions all available alcohol-ester
+(and alcohol-acid) mixture data into mixture where both
+components where in the training set, one component was
+in the training set and neither component was in the training
+set.
+"""
+import os
+
+from evaluator.datasets import PhysicalPropertyDataSet
+from evaluator.properties import Density, EnthalpyOfMixing, ExcessMolarVolume
+
+from nistdataselection.curation.filtering import filter_by_checkmol
+from nistdataselection.processing import load_processed_data_set
+from nistdataselection.utils import SubstanceType
+from nistdataselection.utils.utils import data_frame_to_pdf, property_to_snake_case
+
+chemical_environment_codes = {
+    "caboxylic_acid": "076",
+    "ester": "078",
+}
+
+
+def main():
+    output_directory = "partitioned_alcohol_ester_data"
+    os.makedirs(output_directory, exist_ok=True)
+
+    # Find those alcohols which were included in the training set
+    pure_training_set = PhysicalPropertyDataSet.from_json(
+        os.path.join(
+            "..",
+            "pure_optimisation",
+            "force_balance",
+            "targets",
+            "pure_data",
+            "training_set.json",
+        )
+    )
+    pure_alcohol_set = filter_by_checkmol(
+        pure_training_set.to_pandas(),
+        [
+            chemical_environment_codes["caboxylic_acid"],
+            chemical_environment_codes["ester"],
+        ],
+    )
+
+    training_smiles = {*pure_alcohol_set["Component 1"]}
+
+    for property_type, substance_type in [
+        (Density, SubstanceType.Binary),
+        (EnthalpyOfMixing, SubstanceType.Binary),
+        (ExcessMolarVolume, SubstanceType.Binary),
+    ]:
+
+        full_data_frame = load_processed_data_set(
+            os.path.join("filtered_data", "alcohol_ester"),
+            property_type,
+            substance_type,
+        )
+
+        property_type = property_to_snake_case(property_type)
+
+        file_name = f"{property_type}_{str(substance_type.value)}"
+
+        # Extract properties where both components appear in
+        # in the training set.
+        data_frame = full_data_frame[
+            full_data_frame["Component 1"].isin(training_smiles)
+            & full_data_frame["Component 2"].isin(training_smiles)
+        ]
+
+        base_directory = os.path.join(output_directory, "both_in_training")
+        os.makedirs(base_directory, exist_ok=True)
+
+        data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
+
+        if len(data_frame) > 0:
+
+            data_frame_to_pdf(
+                data_frame, os.path.join(base_directory, file_name + ".pdf")
+            )
+
+        # Extract properties where only one component appears in
+        # in the training set.
+        data_frame = full_data_frame[
+            (
+                full_data_frame["Component 1"].isin(training_smiles)
+                & ~full_data_frame["Component 2"].isin(training_smiles)
+            )
+            | (
+                ~full_data_frame["Component 1"].isin(training_smiles)
+                & full_data_frame["Component 2"].isin(training_smiles)
+            )
+        ]
+
+        base_directory = os.path.join(output_directory, "one_in_training")
+        os.makedirs(base_directory, exist_ok=True)
+
+        data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
+
+        if len(data_frame) > 0:
+
+            data_frame_to_pdf(
+                data_frame, os.path.join(base_directory, file_name + ".pdf")
+            )
+
+        # Extract properties where neither component appears in
+        # in the training set.
+        data_frame = full_data_frame[
+            ~full_data_frame["Component 1"].isin(training_smiles)
+            & ~full_data_frame["Component 2"].isin(training_smiles)
+        ]
+
+        base_directory = os.path.join(output_directory, "neither_in_training")
+        os.makedirs(base_directory, exist_ok=True)
+
+        data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
+
+        if len(data_frame) > 0:
+
+            data_frame_to_pdf(
+                data_frame, os.path.join(base_directory, file_name + ".pdf")
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/studies/mixture_feasibility/benchmark_selection/partition_alcohol_only_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/partition_alcohol_only_data.py
@@ -67,9 +67,7 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-        data_frame_to_pdf(
-            data_frame, os.path.join(base_directory, file_name + ".pdf")
-        )
+        data_frame_to_pdf(data_frame, os.path.join(base_directory, file_name + ".pdf"))
 
         # Extract properties where only one component appears in
         # in the training set.
@@ -88,9 +86,7 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-        data_frame_to_pdf(
-            data_frame, os.path.join(base_directory, file_name + ".pdf")
-        )
+        data_frame_to_pdf(data_frame, os.path.join(base_directory, file_name + ".pdf"))
 
         # Extract properties where neither component appears in
         # in the training set.
@@ -103,9 +99,7 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-        data_frame_to_pdf(
-            data_frame, os.path.join(base_directory, file_name + ".pdf")
-        )
+        data_frame_to_pdf(data_frame, os.path.join(base_directory, file_name + ".pdf"))
 
 
 if __name__ == "__main__":

--- a/studies/mixture_feasibility/benchmark_selection/partition_alcohol_only_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/partition_alcohol_only_data.py
@@ -1,0 +1,121 @@
+"""This script partitions all available alcohol-alcohol
+mixture data into mixture where both components where
+in the training set, one component was in the training
+set and neither component was in the training set.
+"""
+import os
+
+from evaluator.datasets import PhysicalPropertyDataSet
+from evaluator.properties import Density, EnthalpyOfMixing, ExcessMolarVolume
+
+from nistdataselection.curation.filtering import filter_by_checkmol
+from nistdataselection.processing import load_processed_data_set
+from nistdataselection.utils import SubstanceType
+from nistdataselection.utils.utils import data_frame_to_pdf, property_to_snake_case
+
+chemical_environment_codes = {
+    "hydroxy": "027",
+    "alcohol": "028",
+}
+
+
+def main():
+    output_directory = "partitioned_alcohol_only_data"
+    os.makedirs(output_directory, exist_ok=True)
+
+    # Find those alcohols which were included in the training set
+    pure_training_set = PhysicalPropertyDataSet.from_json(
+        os.path.join(
+            "..",
+            "pure_optimisation",
+            "force_balance",
+            "targets",
+            "pure_data",
+            "training_set.json",
+        )
+    )
+    pure_alcohol_set = filter_by_checkmol(
+        pure_training_set.to_pandas(),
+        [chemical_environment_codes["hydroxy"], chemical_environment_codes["alcohol"]],
+    )
+
+    training_smiles = {*pure_alcohol_set["Component 1"]}
+
+    for property_type, substance_type in [
+        (Density, SubstanceType.Binary),
+        (EnthalpyOfMixing, SubstanceType.Binary),
+        (ExcessMolarVolume, SubstanceType.Binary),
+    ]:
+        full_data_frame = load_processed_data_set(
+            os.path.join("filtered_data", "alcohol_alcohol"),
+            property_type,
+            substance_type,
+        )
+
+        property_type = property_to_snake_case(property_type)
+
+        file_name = f"{property_type}_{str(substance_type.value)}"
+
+        # Extract properties where both components appear in
+        # in the training set.
+        data_frame = full_data_frame[
+            full_data_frame["Component 1"].isin(training_smiles)
+            & full_data_frame["Component 2"].isin(training_smiles)
+        ]
+
+        base_directory = os.path.join(output_directory, "both_in_training")
+        os.makedirs(base_directory, exist_ok=True)
+
+        data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
+
+        if len(data_frame) > 0:
+
+            data_frame_to_pdf(
+                data_frame, os.path.join(base_directory, file_name + ".pdf")
+            )
+
+        # Extract properties where only one component appears in
+        # in the training set.
+        data_frame = full_data_frame[
+            (
+                full_data_frame["Component 1"].isin(training_smiles)
+                & ~full_data_frame["Component 2"].isin(training_smiles)
+            )
+            | (
+                ~full_data_frame["Component 1"].isin(training_smiles)
+                & full_data_frame["Component 2"].isin(training_smiles)
+            )
+        ]
+
+        base_directory = os.path.join(output_directory, "one_in_training")
+        os.makedirs(base_directory, exist_ok=True)
+
+        data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
+
+        if len(data_frame) > 0:
+
+            data_frame_to_pdf(
+                data_frame, os.path.join(base_directory, file_name + ".pdf")
+            )
+
+        # Extract properties where neither component appears in
+        # in the training set.
+        data_frame = full_data_frame[
+            ~full_data_frame["Component 1"].isin(training_smiles)
+            & ~full_data_frame["Component 2"].isin(training_smiles)
+        ]
+
+        base_directory = os.path.join(output_directory, "neither_in_training")
+        os.makedirs(base_directory, exist_ok=True)
+
+        data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
+
+        if len(data_frame) > 0:
+
+            data_frame_to_pdf(
+                data_frame, os.path.join(base_directory, file_name + ".pdf")
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/studies/mixture_feasibility/benchmark_selection/partition_ester_ester_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/partition_ester_ester_data.py
@@ -51,9 +51,7 @@ def main():
     ]:
 
         full_data_frame = load_processed_data_set(
-            os.path.join("filtered_data", "ester_ester"),
-            property_type,
-            substance_type,
+            os.path.join("filtered_data", "ester_ester"), property_type, substance_type,
         )
 
         property_type = property_to_snake_case(property_type)
@@ -71,9 +69,7 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-        data_frame_to_pdf(
-            data_frame, os.path.join(base_directory, file_name + ".pdf")
-        )
+        data_frame_to_pdf(data_frame, os.path.join(base_directory, file_name + ".pdf"))
 
         # Extract properties where only one component appears in
         # in the training set.
@@ -92,9 +88,7 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-        data_frame_to_pdf(
-            data_frame, os.path.join(base_directory, file_name + ".pdf")
-        )
+        data_frame_to_pdf(data_frame, os.path.join(base_directory, file_name + ".pdf"))
 
         # Extract properties where neither component appears in
         # in the training set.
@@ -107,9 +101,7 @@ def main():
         os.makedirs(base_directory, exist_ok=True)
 
         data_frame.to_csv(os.path.join(base_directory, file_name + ".csv"), index=False)
-        data_frame_to_pdf(
-            data_frame, os.path.join(base_directory, file_name + ".pdf")
-        )
+        data_frame_to_pdf(data_frame, os.path.join(base_directory, file_name + ".pdf"))
 
 
 if __name__ == "__main__":

--- a/studies/mixture_feasibility/benchmark_selection/partition_ester_ester_data.py
+++ b/studies/mixture_feasibility/benchmark_selection/partition_ester_ester_data.py
@@ -1,7 +1,7 @@
-"""This script partitions all available alcohol-alcohol
-mixture data into mixture where both components where
-in the training set, one component was in the training
-set and neither component was in the training set.
+"""This script partitions all available ester(/acid)-ester(/acid)
+mixture data into mixture where both components where in the training
+set, one component was in the training set and neither component was
+in the training set.
 """
 import os
 
@@ -14,13 +14,13 @@ from nistdataselection.utils import SubstanceType
 from nistdataselection.utils.utils import data_frame_to_pdf, property_to_snake_case
 
 chemical_environment_codes = {
-    "hydroxy": "027",
-    "alcohol": "028",
+    "caboxylic_acid": "076",
+    "ester": "078",
 }
 
 
 def main():
-    output_directory = "partitioned_alcohol_only_data"
+    output_directory = "partitioned_ester_ester_data"
     os.makedirs(output_directory, exist_ok=True)
 
     # Find those alcohols which were included in the training set
@@ -36,7 +36,10 @@ def main():
     )
     pure_alcohol_set = filter_by_checkmol(
         pure_training_set.to_pandas(),
-        [chemical_environment_codes["hydroxy"], chemical_environment_codes["alcohol"]],
+        [
+            chemical_environment_codes["caboxylic_acid"],
+            chemical_environment_codes["ester"],
+        ],
     )
 
     training_smiles = {*pure_alcohol_set["Component 1"]}
@@ -46,8 +49,9 @@ def main():
         (EnthalpyOfMixing, SubstanceType.Binary),
         (ExcessMolarVolume, SubstanceType.Binary),
     ]:
+
         full_data_frame = load_processed_data_set(
-            os.path.join("filtered_data", "alcohol_alcohol"),
+            os.path.join("filtered_data", "ester_ester"),
             property_type,
             substance_type,
         )


### PR DESCRIPTION
## Description

This PR implements the scripts which will be used to construct an initial benchmark set. This benchmark set is expected to be modest in size (~50 pure data points, ~120 mixture data points) so as to be able to rapidly assess the performance of optimisations, but will be complemented by further sets outlined in future PR's. 

## Plan for the Data Set

- We will be less systematic in the selection of those systems to include in the benchmark set, opting instead to aim to curate a set which has a diverse set of molecules with pure density, enthalpy of vaporization data points, and binary enthalpy of mixing, of excess molar volume, and binary mass density data points, without enforcing that substances must have all such be available to be included (as was the case for the training sets). 

- In order to test how well each of the different produced force fields generalise, we initially aim to include binary mixtures of alcohols and alcohols, alcohols and esters (/ acids), and esters (/acids) and esters (/acids).

    - This will likely be expanded to ethers and other such additional moieties, however this will be done after this initial set has been benchmarked against.

- In an attempt to ensure that we are testing the performance of the refit parameters, rather than the full Parsley 1.0.0 force field, we will exclude any

    - aromatic compounds
    - compounds containing 3-4 membered rings.
    - compounds containing alkane chains greater than 6 atoms in length.

  again, this will likely be relaxed in future benchmark sets.

- This set will only contain mixtures whereby neither of the components appear in the training set. Future data sets may then be complement with mixtures which do partially contain training data to further explore interesting results highlighted by this initial set.

## Status
- [x] Ready to go